### PR TITLE
feat(team): Avvia/Spegni Team — spawn e kill agenti da interfaccia web

### DIFF
--- a/web/app/(protected)/team/page.tsx
+++ b/web/app/(protected)/team/page.tsx
@@ -14,7 +14,7 @@ type AgentDef = {
 }
 
 type AgentStatus = 'idle' | 'spawning' | 'active'
-type TeamState = 'idle' | 'starting' | 'ready'
+type TeamState = 'idle' | 'starting' | 'ready' | 'stopping'
 
 /* ── Definizioni agenti ───────────────────────────────────────────── */
 
@@ -105,16 +105,16 @@ export default function TeamPage() {
       setStatuses(prev => {
         const next = { ...prev }
         ALL_AGENTS.forEach(a => {
-          if (activeSessions.has(a.session)) {
-            next[a.session] = 'active'
-          }
+          next[a.session] = activeSessions.has(a.session) ? 'active' : 'idle'
         })
         return next
       })
 
       const allActive = ALL_AGENTS.every(a => activeSessions.has(a.session))
+      const noneActive = ALL_AGENTS.every(a => !activeSessions.has(a.session))
       if (allActive) setTeamState('ready')
-      return allActive
+      if (noneActive) setTeamState(prev => prev === 'stopping' ? 'idle' : prev)
+      return { allActive, noneActive }
     } catch {
       return false
     }
@@ -153,6 +153,25 @@ export default function TeamPage() {
     }
   }
 
+  /* ── Stop team ────────────────────────────────────────────────── */
+
+  const stopTeam = async () => {
+    setTeamState('stopping')
+    setError(null)
+
+    try {
+      const res = await fetch('/api/team/stop-all', { method: 'POST' })
+      const data = await res.json()
+      if (!data.ok) {
+        setError(data.error ?? 'Stop fallito')
+        setTeamState('ready')
+      }
+    } catch {
+      setError('Errore di rete')
+      setTeamState('ready')
+    }
+  }
+
   /* ── Polling ─────────────────────────────────────────────────── */
 
   useEffect(() => {
@@ -160,10 +179,12 @@ export default function TeamPage() {
   }, [fetchStatus])
 
   useEffect(() => {
-    if (teamState !== 'starting') return
+    if (teamState !== 'starting' && teamState !== 'stopping') return
     const interval = setInterval(async () => {
-      const allReady = await fetchStatus()
-      if (allReady) clearInterval(interval)
+      const result = await fetchStatus()
+      if (!result) return
+      if (teamState === 'starting' && result.allActive) clearInterval(interval)
+      if (teamState === 'stopping' && result.noneActive) clearInterval(interval)
     }, 3000)
     return () => clearInterval(interval)
   }, [teamState, fetchStatus])
@@ -296,7 +317,7 @@ export default function TeamPage() {
             <p className="text-[var(--color-muted)] text-[11px] mt-1">Pipeline e comunicazione tra agenti</p>
           </div>
           <div className="flex items-center gap-3">
-            {teamState === 'starting' && (
+            {(teamState === 'starting' || teamState === 'stopping') && (
               <span className="text-[10px] text-[var(--color-muted)] tabular-nums">
                 {activeCount}/{ALL_AGENTS.length} attivi
               </span>
@@ -342,7 +363,51 @@ export default function TeamPage() {
               {teamState === 'idle' && '\u25B6 Avvia Team'}
               {teamState === 'starting' && '\u21BB Avvio in corso...'}
               {teamState === 'ready' && '\u2713 Team Pronto'}
+              {teamState === 'stopping' && '\u21BB Avvio in corso...'}
             </button>
+            {(teamState === 'ready' || activeCount > 0) && teamState !== 'stopping' && (
+              <button
+                onClick={stopTeam}
+                style={{
+                  border: '1px solid var(--color-border)',
+                  color: 'var(--color-muted)',
+                  background: 'transparent',
+                  fontFamily: 'inherit',
+                  fontSize: '11px',
+                  padding: '6px 16px',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  letterSpacing: '0.05em',
+                  transition: 'all 0.25s',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.borderColor = '#f44336'
+                  e.currentTarget.style.color = '#f44336'
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.borderColor = 'var(--color-border)'
+                  e.currentTarget.style.color = 'var(--color-muted)'
+                }}
+              >
+                {'\u25A0'} Spegni Team
+              </button>
+            )}
+            {teamState === 'stopping' && (
+              <span
+                style={{
+                  border: '1px solid #f44336',
+                  color: '#f44336',
+                  background: 'rgba(244,67,54,0.05)',
+                  fontFamily: 'inherit',
+                  fontSize: '11px',
+                  padding: '6px 16px',
+                  borderRadius: '4px',
+                  letterSpacing: '0.05em',
+                }}
+              >
+                {'\u21BB'} Spegnimento...
+              </span>
+            )}
           </div>
         </div>
         {error && (

--- a/web/app/(protected)/team/page.tsx
+++ b/web/app/(protected)/team/page.tsx
@@ -3,31 +3,66 @@
 import Link from 'next/link'
 import { useRef, useState, useEffect, useCallback, type ReactNode } from 'react'
 
+/* ── Tipi ─────────────────────────────────────────────────────────── */
+
 type AgentDef = {
   emoji: string
   role: string
   color: string
   link: string | null
+  session: string
 }
 
-const CAPITANO: AgentDef = { emoji: '👨‍✈️', role: 'Capitano', color: '#ff9100', link: '/capitano' }
+type AgentStatus = 'idle' | 'spawning' | 'active'
+type TeamState = 'idle' | 'starting' | 'ready'
+
+/* ── Definizioni agenti ───────────────────────────────────────────── */
+
+const CAPITANO: AgentDef = { emoji: '\u{1F468}\u200D\u2708\uFE0F', role: 'Capitano', color: '#ff9100', link: '/capitano', session: 'ALFA' }
 
 const PIPELINE: AgentDef[] = [
-  { emoji: '🕵️', role: 'Scout', color: '#2196f3', link: '/scout' },
-  { emoji: '👨‍🔬', role: 'Analista', color: '#00e676', link: '/analista' },
-  { emoji: '👨‍💻', role: 'Scorer', color: '#b388ff', link: '/scorer' },
-  { emoji: '👨‍🏫', role: 'Scrittore', color: '#ffd600', link: '/scrittore' },
-  { emoji: '👨‍⚖️', role: 'Critico', color: '#f44336', link: '/critico' },
+  { emoji: '\uD83D\uDD75\uFE0F', role: 'Scout',     color: '#2196f3', link: '/scout',     session: 'SCOUT-1' },
+  { emoji: '\u{1F468}\u200D\uD83D\uDD2C', role: 'Analista',  color: '#00e676', link: '/analista',  session: 'ANALISTA-1' },
+  { emoji: '\u{1F468}\u200D\uD83D\uDCBB', role: 'Scorer',    color: '#b388ff', link: '/scorer',    session: 'SCORER-1' },
+  { emoji: '\u{1F468}\u200D\uD83C\uDFEB', role: 'Scrittore', color: '#ffd600', link: '/scrittore', session: 'SCRITTORE-1' },
+  { emoji: '\u{1F468}\u200D\u2696\uFE0F', role: 'Critico',   color: '#f44336', link: '/critico',   session: 'CRITICO' },
 ]
 
-const SENTINELLA: AgentDef = { emoji: '💂', role: 'Sentinella', color: '#607d8b', link: null }
+const SENTINELLA: AgentDef = { emoji: '\uD83D\uDC82', role: 'Sentinella', color: '#607d8b', link: null, session: 'SENTINELLA' }
 
-function AgentNode({ agent, size = 'md' }: { agent: AgentDef; size?: 'lg' | 'md' | 'sm' }) {
+const ALL_AGENTS: AgentDef[] = [CAPITANO, ...PIPELINE, SENTINELLA]
+
+/* ── Componenti ───────────────────────────────────────────────────── */
+
+function StatusDot({ status }: { status: AgentStatus }) {
+  const bg =
+    status === 'active' ? '#4caf50' :
+    status === 'spawning' ? '#ffc107' :
+    'rgba(255,255,255,0.15)'
+  return (
+    <span
+      className={status === 'spawning' ? 'status-pulse' : ''}
+      style={{
+        display: 'inline-block',
+        width: 6,
+        height: 6,
+        borderRadius: '50%',
+        backgroundColor: bg,
+        transition: 'background-color 0.3s',
+      }}
+    />
+  )
+}
+
+function AgentNode({ agent, size = 'md', status = 'idle' }: { agent: AgentDef; size?: 'lg' | 'md' | 'sm'; status?: AgentStatus }) {
   const sizeClass = size === 'lg' ? 'text-3xl' : size === 'sm' ? 'text-xl' : 'text-2xl'
   const node = (
     <div className="text-center group">
       <div className={`${sizeClass} leading-none mb-1.5 transition-transform group-hover:scale-110`}>{agent.emoji}</div>
       <div className="text-[10px] font-semibold tracking-wide" style={{ color: agent.color }}>{agent.role}</div>
+      <div className="mt-1 flex justify-center">
+        <StatusDot status={status} />
+      </div>
     </div>
   )
   if (agent.link) {
@@ -36,12 +71,104 @@ function AgentNode({ agent, size = 'md' }: { agent: AgentDef; size?: 'lg' | 'md'
   return node
 }
 
+/* ── Pagina ────────────────────────────────────────────────────────── */
+
 export default function TeamPage() {
   const containerRef = useRef<HTMLDivElement>(null)
   const capRef = useRef<HTMLDivElement>(null)
   const pipeRefs = useRef<(HTMLDivElement | null)[]>(new Array(PIPELINE.length).fill(null))
   const sentRef = useRef<HTMLDivElement>(null)
   const [svgData, setSvgData] = useState<{ w: number; h: number; lines: ReactNode[] } | null>(null)
+
+  /* ── Stato team ──────────────────────────────────────────────── */
+
+  const [statuses, setStatuses] = useState<Record<string, AgentStatus>>(() => {
+    const init: Record<string, AgentStatus> = {}
+    ALL_AGENTS.forEach(a => { init[a.session] = 'idle' })
+    return init
+  })
+  const [teamState, setTeamState] = useState<TeamState>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const activeCount = ALL_AGENTS.filter(a => statuses[a.session] === 'active').length
+
+  /* ── Fetch status ────────────────────────────────────────────── */
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/team/status')
+      const data = await res.json()
+      const activeSessions = new Set<string>(
+        (data.agents ?? []).map((a: { session: string }) => a.session)
+      )
+
+      setStatuses(prev => {
+        const next = { ...prev }
+        ALL_AGENTS.forEach(a => {
+          if (activeSessions.has(a.session)) {
+            next[a.session] = 'active'
+          }
+        })
+        return next
+      })
+
+      const allActive = ALL_AGENTS.every(a => activeSessions.has(a.session))
+      if (allActive) setTeamState('ready')
+      return allActive
+    } catch {
+      return false
+    }
+  }, [])
+
+  /* ── Avvio team ──────────────────────────────────────────────── */
+
+  const startTeam = async () => {
+    setTeamState('starting')
+    setError(null)
+    setStatuses(prev => {
+      const next = { ...prev }
+      ALL_AGENTS.forEach(a => {
+        if (next[a.session] !== 'active') next[a.session] = 'spawning'
+      })
+      return next
+    })
+
+    try {
+      const res = await fetch('/api/team/start-all', { method: 'POST' })
+      const data = await res.json()
+      if (!data.ok) {
+        setError(data.error ?? 'Avvio fallito')
+        setTeamState('idle')
+        setStatuses(prev => {
+          const next = { ...prev }
+          ALL_AGENTS.forEach(a => {
+            if (next[a.session] === 'spawning') next[a.session] = 'idle'
+          })
+          return next
+        })
+      }
+    } catch {
+      setError('Errore di rete')
+      setTeamState('idle')
+    }
+  }
+
+  /* ── Polling ─────────────────────────────────────────────────── */
+
+  useEffect(() => {
+    fetchStatus()
+  }, [fetchStatus])
+
+  useEffect(() => {
+    if (teamState !== 'starting') return
+    const interval = setInterval(async () => {
+      const allReady = await fetchStatus()
+      if (allReady) clearInterval(interval)
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [teamState, fetchStatus])
+
+  /* ── SVG measurement ─────────────────────────────────────────── */
 
   const measure = useCallback(() => {
     const container = containerRef.current
@@ -63,7 +190,6 @@ export default function TeamPage() {
 
     const lines: ReactNode[] = []
 
-    // Defs: arrow markers e gradienti
     lines.push(
       <defs key="defs">
         <marker id="arrowRight" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
@@ -78,7 +204,6 @@ export default function TeamPage() {
       </defs>
     )
 
-    // Linee dal Capitano a ogni agente della pipeline (tratteggiate, arancione)
     const capCx = capR.x + capR.w / 2
     const capBy = capR.y + capR.h + 2
 
@@ -86,39 +211,23 @@ export default function TeamPage() {
       const px = pr!.x + pr!.w / 2
       const py = pr!.y - 2
       lines.push(
-        <line
-          key={`cap-${i}`}
-          x1={capCx} y1={capBy}
-          x2={px} y2={py}
-          stroke="#ff9100"
-          strokeWidth="1"
-          strokeDasharray="4 3"
-          opacity="0.35"
-        />
+        <line key={`cap-${i}`} x1={capCx} y1={capBy} x2={px} y2={py}
+          stroke="#ff9100" strokeWidth="1" strokeDasharray="4 3" opacity="0.35" />
       )
     })
 
-    // Frecce orizzontali tra nodi pipeline (sinistra → destra)
     for (let i = 0; i < PIPELINE.length - 1; i++) {
       const from = pRects[i]!
       const to = pRects[i + 1]!
       const y = from.y + from.h / 2
       const x1 = from.x + from.w + 4
       const x2 = to.x - 4
-
       lines.push(
-        <line
-          key={`pipe-${i}`}
-          x1={x1} y1={y}
-          x2={x2} y2={y}
-          stroke={`url(#pg-${i})`}
-          strokeWidth="2"
-          markerEnd="url(#arrowRight)"
-        />
+        <line key={`pipe-${i}`} x1={x1} y1={y} x2={x2} y2={y}
+          stroke={`url(#pg-${i})`} strokeWidth="2" markerEnd="url(#arrowRight)" />
       )
     }
 
-    // Feedback tratteggiato: Critico → Scrittore (arco sotto)
     const scrittore = pRects[3]!
     const critico = pRects[4]!
     const fbY = critico.y + critico.h + 16
@@ -126,50 +235,27 @@ export default function TeamPage() {
     const fbX2 = scrittore.x + scrittore.w / 2
 
     lines.push(
-      <path
-        key="feedback"
+      <path key="feedback"
         d={`M ${fbX1} ${critico.y + critico.h + 2} V ${fbY} H ${fbX2} V ${scrittore.y + scrittore.h + 2}`}
-        stroke="#f44336"
-        strokeWidth="1.5"
-        strokeDasharray="4 3"
-        fill="none"
-        opacity="0.5"
-      />
+        stroke="#f44336" strokeWidth="1.5" strokeDasharray="4 3" fill="none" opacity="0.5" />
     )
     lines.push(
-      <text
-        key="fb-lbl"
-        x={(fbX1 + fbX2) / 2}
-        y={fbY + 12}
-        fontSize="9"
-        fill="#f44336"
-        fontFamily="ui-monospace, monospace"
-        textAnchor="middle"
-        opacity="0.7"
-      >
+      <text key="fb-lbl" x={(fbX1 + fbX2) / 2} y={fbY + 12}
+        fontSize="9" fill="#f44336" fontFamily="ui-monospace, monospace" textAnchor="middle" opacity="0.7">
         feedback
       </text>
     )
 
-    // Sentinella: linee tratteggiate verso tutti i nodi pipeline
     const sentR = getR(sentRef.current)
     if (sentR) {
       const sx = sentR.x + sentR.w / 2
       const sy = sentR.y + sentR.h
-
       pRects.forEach((pr, i) => {
         const px = pr!.x + pr!.w / 2
         const py = pr!.y
         lines.push(
-          <line
-            key={`sent-${i}`}
-            x1={sx} y1={sy}
-            x2={px} y2={py}
-            stroke="#607d8b"
-            strokeWidth="1"
-            strokeDasharray="2 4"
-            opacity="0.18"
-          />
+          <line key={`sent-${i}`} x1={sx} y1={sy} x2={px} y2={py}
+            stroke="#607d8b" strokeWidth="1" strokeDasharray="2 4" opacity="0.18" />
         )
       })
     }
@@ -183,8 +269,19 @@ export default function TeamPage() {
     return () => { clearTimeout(t); window.removeEventListener('resize', measure) }
   }, [measure])
 
+  /* ── Render ──────────────────────────────────────────────────── */
+
   return (
     <div style={{ animation: 'fade-in 0.35s ease both' }}>
+
+      {/* Pulse animation for spawning dots */}
+      <style>{`
+        @keyframes status-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
+        }
+        .status-pulse { animation: status-pulse 1.5s ease-in-out infinite; }
+      `}</style>
 
       {/* Header */}
       <div className="mb-8 pb-6 border-b border-[var(--color-border)]">
@@ -193,10 +290,64 @@ export default function TeamPage() {
           <span className="text-[var(--color-border)]">/</span>
           <span className="text-[10px] text-[var(--color-muted)]">Team</span>
         </div>
-        <div className="mt-3">
-          <h1 className="text-2xl font-bold tracking-tight text-[var(--color-white)]">Job Hunter Team</h1>
-          <p className="text-[var(--color-muted)] text-[11px] mt-1">Pipeline e comunicazione tra agenti</p>
+        <div className="mt-3 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-[var(--color-white)]">Job Hunter Team</h1>
+            <p className="text-[var(--color-muted)] text-[11px] mt-1">Pipeline e comunicazione tra agenti</p>
+          </div>
+          <div className="flex items-center gap-3">
+            {teamState === 'starting' && (
+              <span className="text-[10px] text-[var(--color-muted)] tabular-nums">
+                {activeCount}/{ALL_AGENTS.length} attivi
+              </span>
+            )}
+            <button
+              onClick={startTeam}
+              disabled={teamState !== 'idle'}
+              style={{
+                border: `1px solid ${
+                  teamState === 'ready' ? '#4caf50' :
+                  teamState === 'starting' ? '#ffc107' :
+                  'var(--color-border)'
+                }`,
+                color:
+                  teamState === 'ready' ? '#4caf50' :
+                  teamState === 'starting' ? '#ffc107' :
+                  'var(--color-muted)',
+                background:
+                  teamState === 'ready' ? 'rgba(76,175,80,0.1)' :
+                  teamState === 'starting' ? 'rgba(255,193,7,0.05)' :
+                  'transparent',
+                fontFamily: 'inherit',
+                fontSize: '11px',
+                padding: '6px 16px',
+                borderRadius: '4px',
+                cursor: teamState === 'idle' ? 'pointer' : 'default',
+                letterSpacing: '0.05em',
+                transition: 'all 0.25s',
+              }}
+              onMouseEnter={e => {
+                if (teamState === 'idle') {
+                  e.currentTarget.style.borderColor = '#4caf50'
+                  e.currentTarget.style.color = '#4caf50'
+                }
+              }}
+              onMouseLeave={e => {
+                if (teamState === 'idle') {
+                  e.currentTarget.style.borderColor = 'var(--color-border)'
+                  e.currentTarget.style.color = 'var(--color-muted)'
+                }
+              }}
+            >
+              {teamState === 'idle' && '\u25B6 Avvia Team'}
+              {teamState === 'starting' && '\u21BB Avvio in corso...'}
+              {teamState === 'ready' && '\u2713 Team Pronto'}
+            </button>
+          </div>
         </div>
+        {error && (
+          <p className="text-[11px] mt-2" style={{ color: '#f44336' }}>{error}</p>
+        )}
       </div>
 
       {/* Desktop: Pyramid layout */}
@@ -210,21 +361,18 @@ export default function TeamPage() {
         {/* Capitano + Sentinella — top center */}
         <div className="flex justify-center items-end gap-12 mb-20">
           <div ref={capRef}>
-            <AgentNode agent={CAPITANO} size="lg" />
+            <AgentNode agent={CAPITANO} size="lg" status={statuses[CAPITANO.session]} />
           </div>
           <div ref={sentRef}>
-            <AgentNode agent={SENTINELLA} size="md" />
+            <AgentNode agent={SENTINELLA} size="md" status={statuses[SENTINELLA.session]} />
           </div>
         </div>
 
         {/* Pipeline row — left to right */}
         <div className="flex items-center justify-center gap-16">
           {PIPELINE.map((agent, i) => (
-            <div
-              key={agent.role}
-              ref={el => { pipeRefs.current[i] = el }}
-            >
-              <AgentNode agent={agent} />
+            <div key={agent.role} ref={el => { pipeRefs.current[i] = el }}>
+              <AgentNode agent={agent} status={statuses[agent.session]} />
             </div>
           ))}
         </div>
@@ -233,15 +381,15 @@ export default function TeamPage() {
       {/* Mobile: vertical flow */}
       <div className="sm:hidden flex flex-col items-center gap-4">
         <div className="flex items-end gap-6">
-          <AgentNode agent={CAPITANO} size="lg" />
-          <AgentNode agent={SENTINELLA} size="md" />
+          <AgentNode agent={CAPITANO} size="lg" status={statuses[CAPITANO.session]} />
+          <AgentNode agent={SENTINELLA} size="md" status={statuses[SENTINELLA.session]} />
         </div>
-        <div className="text-[var(--color-dim)] text-xs opacity-50">▼</div>
+        <div className="text-[var(--color-dim)] text-xs opacity-50">{'\u25BC'}</div>
         {PIPELINE.map((agent, i) => (
           <div key={agent.role} className="flex flex-col items-center">
-            <AgentNode agent={agent} />
+            <AgentNode agent={agent} status={statuses[agent.session]} />
             {i < PIPELINE.length - 1 && (
-              <div className="text-[var(--color-dim)] text-xs opacity-50 my-2">→</div>
+              <div className="text-[var(--color-dim)] text-xs opacity-50 my-2">{'\u2192'}</div>
             )}
           </div>
         ))}

--- a/web/app/api/team/start-all/route.ts
+++ b/web/app/api/team/start-all/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server'
+import { getWorkspacePath } from '@/lib/workspace'
+import { runBash } from '@/lib/shell'
+import path from 'path'
+import fs from 'fs'
+
+export const dynamic = 'force-dynamic'
+
+const TEAM = [
+  { role: 'alfa',       session: 'ALFA',        effort: 'high',   dir: 'alfa' },
+  { role: 'scout',      session: 'SCOUT-1',     effort: 'high',   dir: 'scout-1' },
+  { role: 'analista',   session: 'ANALISTA-1',  effort: 'high',   dir: 'analista-1' },
+  { role: 'scorer',     session: 'SCORER-1',    effort: 'medium', dir: 'scorer-1' },
+  { role: 'scrittore',  session: 'SCRITTORE-1', effort: 'high',   dir: 'scrittore-1' },
+  { role: 'critico',    session: 'CRITICO',     effort: 'high',   dir: 'critico' },
+  { role: 'sentinella', session: 'SENTINELLA',  effort: 'low',    dir: 'sentinella' },
+]
+
+const DESCRIPTIONS: Record<string, string> = {
+  alfa:       'Coordini la pipeline di ricerca lavoro del team.',
+  scout:      'Cerchi posizioni lavorative online e le inserisci nel database.',
+  analista:   'Analizzi le job description e le aziende per estrarre requisiti chiave.',
+  scorer:     'Calcoli il punteggio di match tra il profilo del candidato e le posizioni.',
+  scrittore:  'Scrivi CV personalizzati e cover letter per ogni posizione.',
+  critico:    'Revisioni la qualita dei CV e delle cover letter, fornendo feedback.',
+  sentinella: 'Monitori il sistema, token usage, rate limit e stato degli agenti.',
+}
+
+const DISPLAY_NAMES: Record<string, string> = {
+  alfa: 'Capitano (Alfa)', scout: 'Scout', analista: 'Analista',
+  scorer: 'Scorer', scrittore: 'Scrittore', critico: 'Critico', sentinella: 'Sentinella',
+}
+
+function minimalClaudeMd(role: string): string {
+  return `# ${DISPLAY_NAMES[role] ?? role}
+
+Sei l'agente **${DISPLAY_NAMES[role] ?? role}** del Job Hunter Team.
+${DESCRIPTIONS[role] ?? ''}
+
+## Regole
+- Comunica in italiano
+- Lavora nella tua directory di workspace
+- Collabora con gli altri agenti del team
+`
+}
+
+export async function POST() {
+  try {
+    const workspace = await getWorkspacePath()
+    if (!workspace) {
+      return NextResponse.json(
+        { ok: false, error: 'Workspace non configurato. Seleziona una cartella dalla pagina principale.' },
+        { status: 400 }
+      )
+    }
+
+    const repoRoot = path.resolve(process.cwd(), '..')
+    const results: { session: string; role: string; status: 'started' | 'already_active' | 'error'; error?: string }[] = []
+
+    for (const agent of TEAM) {
+      const agentDir = path.join(workspace, agent.dir)
+      const claudeMd = path.join(agentDir, 'CLAUDE.md')
+      const templatePath = path.join(repoRoot, 'agents', agent.role, `${agent.role}.md`)
+
+      // 1. Crea directory agente
+      fs.mkdirSync(agentDir, { recursive: true })
+
+      // 2. Crea CLAUDE.md se non presente
+      if (!fs.existsSync(claudeMd)) {
+        if (fs.existsSync(templatePath) && fs.statSync(templatePath).size > 0) {
+          fs.copyFileSync(templatePath, claudeMd)
+        } else {
+          fs.writeFileSync(claudeMd, minimalClaudeMd(agent.role))
+        }
+      }
+
+      // 3. Controlla se sessione tmux gia attiva
+      try {
+        const { stdout } = await runBash(
+          `tmux has-session -t "${agent.session}" 2>&1 && echo "EXISTS" || echo "NEW"`
+        )
+        if (stdout.trim() === 'EXISTS') {
+          results.push({ session: agent.session, role: agent.role, status: 'already_active' })
+          continue
+        }
+      } catch {
+        // Sessione non esiste, procedi
+      }
+
+      // 4. Avvia sessione tmux con claude CLI
+      try {
+        await runBash(`tmux new-session -d -s "${agent.session}" -c "${agentDir}"`)
+        await runBash(
+          `tmux send-keys -t "${agent.session}" "claude --dangerously-skip-permissions --effort ${agent.effort}" C-m`
+        )
+        results.push({ session: agent.session, role: agent.role, status: 'started' })
+      } catch (err: any) {
+        results.push({ session: agent.session, role: agent.role, status: 'error', error: err?.message })
+      }
+    }
+
+    return NextResponse.json({ ok: true, results })
+  } catch (err: any) {
+    return NextResponse.json(
+      { ok: false, error: err?.message ?? 'Avvio team fallito' },
+      { status: 500 }
+    )
+  }
+}

--- a/web/app/api/team/stop-all/route.ts
+++ b/web/app/api/team/stop-all/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { runBash } from '@/lib/shell'
+
+export const dynamic = 'force-dynamic'
+
+const SESSIONS = [
+  'ALFA', 'SCOUT-1', 'ANALISTA-1', 'SCORER-1', 'SCRITTORE-1', 'CRITICO', 'SENTINELLA',
+]
+
+export async function POST() {
+  try {
+    const results: { session: string; status: 'killed' | 'not_active' | 'error'; error?: string }[] = []
+
+    for (const session of SESSIONS) {
+      try {
+        const { stdout } = await runBash(
+          `tmux has-session -t "${session}" 2>&1 && echo "EXISTS" || echo "NONE"`
+        )
+        if (stdout.trim() !== 'EXISTS') {
+          results.push({ session, status: 'not_active' })
+          continue
+        }
+        await runBash(`tmux kill-session -t "${session}"`)
+        results.push({ session, status: 'killed' })
+      } catch (err: any) {
+        results.push({ session, status: 'error', error: err?.message })
+      }
+    }
+
+    return NextResponse.json({ ok: true, results })
+  } catch (err: any) {
+    return NextResponse.json(
+      { ok: false, error: err?.message ?? 'Stop team fallito' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- **API POST /api/team/start-all**: crea cartelle agenti nel workspace, genera CLAUDE.md (da template o minimale), spawna sessioni tmux con claude CLI per 7 agenti
- **API POST /api/team/stop-all**: killa tutte le sessioni tmux degli agenti del team
- **Pagina /team aggiornata**: pulsante "Avvia Team" con status dots live (idle/spawning/active), pulsante "Spegni Team" visibile quando il team e' attivo, polling automatico ogni 3s

## Task file
`~/.jht-dev/tasks/task-fs-001.md`

## Commits
- `d77584c` feat(team): pulsante Avvia Team con spawn agenti e status live
- `e490111` feat(team): pulsante Spegni Team per killare tutte le sessioni agenti

## File modificati
- `web/app/api/team/start-all/route.ts` (nuovo)
- `web/app/api/team/stop-all/route.ts` (nuovo)
- `web/app/(protected)/team/page.tsx` (aggiornato)