### PR TITLE
fix: workspace change button + elegant path breadcrumb

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,6 +15,7 @@ function LandingContent() {
   const router = useRouter()
   const authError = params.get('error') === 'auth_failed'
   const wantsLogin = params.get('login') === 'true'
+  const wantsChange = params.get('change') === 'true'
 
   // --- Workspace state (modalita' locale) ---
   const [workspace, setWs] = useState('')
@@ -37,14 +38,15 @@ function LandingContent() {
         .then(data => {
           if (data.path) {
             setWs(data.path)
+            setInputPath(data.path)
             setWsStatus({ hasDb: data.hasDb, hasProfile: data.hasProfile })
-            // Se ha gia' un DB, vai alla dashboard
-            if (data.hasDb) router.replace('/dashboard')
+            // Se ha gia' un DB e l'utente NON ha cliccato "cambia", vai alla dashboard
+            if (data.hasDb && !wantsChange) router.replace('/dashboard')
           }
         })
         .catch(() => {})
     }
-  }, [router, wantsLogin])
+  }, [router, wantsLogin, wantsChange])
 
   const handleBrowse = async () => {
     setBrowsing(true)

--- a/web/components/Navbar.tsx
+++ b/web/components/Navbar.tsx
@@ -87,15 +87,7 @@ export default function Navbar({ user, workspace }: NavbarProps) {
             <LogoutButton />
           </div>
         ) : workspace ? (
-          <div className="flex items-center gap-3">
-            <div className="hidden sm:flex items-center gap-2">
-              <span className="text-[10px] text-[var(--color-dim)]">workspace</span>
-              <span className="text-[10px] text-[var(--color-muted)] font-mono max-w-[200px] truncate">{workspace.split('/').pop()}</span>
-            </div>
-            <Link href="/" className="text-[10px] font-semibold tracking-widest uppercase text-[var(--color-dim)] hover:text-[var(--color-muted)] transition-colors no-underline">
-              cambia
-            </Link>
-          </div>
+          <WorkspacePath path={workspace} />
         ) : (
           <div className="flex items-center gap-2">
             <span className="text-[10px] text-[var(--color-dim)] hidden sm:block">locale</span>
@@ -115,6 +107,38 @@ function NavLink({ href, children, accent }: { href: string; children: React.Rea
       style={{ color: accent ?? 'var(--color-muted)' } as React.CSSProperties}
     >
       {children}
+    </Link>
+  )
+}
+
+function WorkspacePath({ path }: { path: string }) {
+  const segments = path.split('/').filter(Boolean)
+  // Rimuovi i segmenti "Users" e username per un path piu' pulito
+  const homeIdx = segments.indexOf('Users')
+  const display = homeIdx !== -1 && homeIdx + 2 < segments.length
+    ? segments.slice(homeIdx + 2)
+    : segments.slice(-3)
+
+  return (
+    <Link
+      href="/?change=true"
+      className="hidden sm:flex items-center gap-1.5 max-w-[320px] no-underline hover:opacity-75 transition-opacity cursor-pointer"
+    >
+      <span className="text-[11px] flex-shrink-0" role="img" aria-label="cartella">📁</span>
+      {display.map((seg, i) => (
+        <span key={i} className="flex items-center gap-1.5 min-w-0">
+          {i > 0 && <span className="text-[9px] text-[var(--color-dim)] flex-shrink-0">›</span>}
+          <span
+            className="text-[10px] font-medium truncate"
+            style={{
+              color: i === display.length - 1 ? 'var(--color-bright)' : 'var(--color-dim)',
+              maxWidth: i === display.length - 1 ? '140px' : '80px',
+            }}
+          >
+            {seg}
+          </span>
+        </span>
+      ))}
     </Link>
   )
 }


### PR DESCRIPTION
## Summary
- **Fix redirect loop**: il pulsante "Cambia" workspace ora funziona — non fa piu' flash/redirect alla dashboard
- **Path breadcrumb elegante**: 📁 Documents › folder › subfolder nella navbar, cliccabile per cambiare workspace
- **Rimosso link "Cambia"**: il path stesso e' il link

## File modificati
- `web/app/page.tsx` — logica `wantsChange` per skip auto-redirect
- `web/components/Navbar.tsx` — componente `WorkspacePath` cliccabile

## Task file
`~/.jht-dev/tasks/task-fs-003.md`

## Test plan
- [ ] Cliccare sul path breadcrumb nella navbar → deve aprire pagina selezione workspace
- [ ] Da pagina selezione, scegliere workspace e entrare in dashboard → funziona normalmente
- [ ] Navigazione diretta a `/` senza `?change=true` → redirect a dashboard (comportamento invariato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)