### PR TITLE
fix(ci): CI verde — rimuovi @ts-expect-error inutilizzato + prettier web/app

### DIFF
--- a/web/app/(protected)/positions/PositionsFilterSidebar.tsx
+++ b/web/app/(protected)/positions/PositionsFilterSidebar.tsx
@@ -33,7 +33,10 @@ function familyKey(rf: string | null): string {
 
 function csv(v: string | null): string[] {
   if (!v) return [];
-  return v.split(",").map((s) => s.trim()).filter(Boolean);
+  return v
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 function parseBands(v: string | null): ScoreRange[] {
@@ -88,7 +91,10 @@ export default function PositionsFilterSidebar() {
   }
   function toggleInParam(key: string, value: string) {
     const cur = csv(sp.get(key));
-    setParam(key, cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value]);
+    setParam(
+      key,
+      cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value],
+    );
   }
   function toggleFamily(f: string) {
     // Cambiare scope tipo ricalcola i bin score: pulisco selezione score.
@@ -145,7 +151,9 @@ export default function PositionsFilterSidebar() {
   function resetAll() {
     setScoreAnchor(null);
     const next = new URLSearchParams(sp.toString());
-    ["family", "country", "city", "band", "noscore"].forEach((k) => next.delete(k));
+    ["family", "country", "city", "band", "noscore"].forEach((k) =>
+      next.delete(k),
+    );
     pushURL(next);
   }
 
@@ -159,7 +167,8 @@ export default function PositionsFilterSidebar() {
     selectedCountries.length > 0 || selectedCities.length > 0;
   const passLocation = (p: Facet) => {
     if (!locationActive) return true;
-    if (selectedCities.includes(cityKey(p.loc_country, p.loc_city))) return true;
+    if (selectedCities.includes(cityKey(p.loc_country, p.loc_city)))
+      return true;
     if (selectedCountries.includes(countryKey(p.loc_country))) return true;
     return false;
   };
@@ -246,7 +255,10 @@ export default function PositionsFilterSidebar() {
       cities: Array.from(cityMap.entries())
         .map(([key, count]) => ({
           key,
-          label: key.split("|")[1] === "(country-only)" ? "(senza città)" : key.split("|")[1],
+          label:
+            key.split("|")[1] === "(country-only)"
+              ? "(senza città)"
+              : key.split("|")[1],
           count,
         }))
         .sort((a, b) => b.count - a.count),
@@ -296,10 +308,7 @@ export default function PositionsFilterSidebar() {
   }
 
   return (
-    <aside
-      className="shrink-0 flex flex-col gap-4 pr-1"
-      style={{ width: 300 }}
-    >
+    <aside className="shrink-0 flex flex-col gap-4 pr-1" style={{ width: 300 }}>
       {/* Header sidebar */}
       <div className="flex items-center justify-between">
         <span
@@ -416,7 +425,10 @@ export default function PositionsFilterSidebar() {
       {/* Albero Location */}
       <Section title="Location" badge={`${locationTree.length} · ${treeTotal}`}>
         {locationTree.length === 0 ? (
-          <div className="text-[11px] py-3 text-center" style={{ color: "var(--color-dim)" }}>
+          <div
+            className="text-[11px] py-3 text-center"
+            style={{ color: "var(--color-dim)" }}
+          >
             Nessun dato
           </div>
         ) : (
@@ -428,7 +440,10 @@ export default function PositionsFilterSidebar() {
               const isOpen = openCountry === country.country;
               const isSelected = selectedCountries.includes(country.country);
               return (
-                <li key={country.country} style={{ borderColor: "var(--color-border)" }}>
+                <li
+                  key={country.country}
+                  style={{ borderColor: "var(--color-border)" }}
+                >
                   <div
                     onClick={() => {
                       setOpenCountry(isOpen ? null : country.country);
@@ -492,7 +507,10 @@ export default function PositionsFilterSidebar() {
                       {country.cities.map((city) => {
                         const isCitySel = selectedCities.includes(city.key);
                         return (
-                          <li key={city.key} style={{ borderColor: "var(--color-border)" }}>
+                          <li
+                            key={city.key}
+                            style={{ borderColor: "var(--color-border)" }}
+                          >
                             <div
                               onClick={() => toggleInParam("city", city.key)}
                               className="px-3 py-1 pl-7 text-[10.5px] flex items-baseline justify-between gap-2 cursor-pointer hover:bg-[rgba(255,255,255,0.04)] transition-colors"

--- a/web/app/(protected)/positions/page.tsx
+++ b/web/app/(protected)/positions/page.tsx
@@ -313,307 +313,309 @@ export default async function PositionsPage({ searchParams }: PageProps) {
       <div className="flex gap-6 items-start">
         <PositionsFilterSidebar />
         <div className="flex-1 min-w-0">
-      {/* ── Filtri (wizard a sinistra, righe-per-pagina a destra) ── */}
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <FiltersWizard availableSources={availableSources} />
-        <div className="flex items-center gap-1.5">
-          <span className="text-[9.5px] uppercase tracking-[0.14em] text-[var(--color-dim)]">
-            Righe per pagina
-          </span>
-          {PAGE_SIZE_OPTIONS.map((size) => (
-            <Link
-              key={size}
-              href={buildHref({ pageSize: String(size), page: "1" })}
-              className="px-2 py-0.5 text-[10px] font-semibold rounded-full border transition-colors no-underline"
-              style={
-                pageSize === size
-                  ? {
-                      color: "var(--color-bright)",
-                      borderColor: "var(--color-green)",
-                      background: "var(--color-card)",
-                    }
-                  : {
-                      color: "var(--color-dim)",
-                      borderColor: "var(--color-border)",
-                    }
-              }
-            >
-              {size}
-            </Link>
-          ))}
-        </div>
-      </div>
+          {/* ── Filtri (wizard a sinistra, righe-per-pagina a destra) ── */}
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <FiltersWizard availableSources={availableSources} />
+            <div className="flex items-center gap-1.5">
+              <span className="text-[9.5px] uppercase tracking-[0.14em] text-[var(--color-dim)]">
+                Righe per pagina
+              </span>
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <Link
+                  key={size}
+                  href={buildHref({ pageSize: String(size), page: "1" })}
+                  className="px-2 py-0.5 text-[10px] font-semibold rounded-full border transition-colors no-underline"
+                  style={
+                    pageSize === size
+                      ? {
+                          color: "var(--color-bright)",
+                          borderColor: "var(--color-green)",
+                          background: "var(--color-card)",
+                        }
+                      : {
+                          color: "var(--color-dim)",
+                          borderColor: "var(--color-border)",
+                        }
+                  }
+                >
+                  {size}
+                </Link>
+              ))}
+            </div>
+          </div>
 
-      {/* ── Table ───────────────────────────────────────────────── */}
-      {/* La pagina /positions è in MainChrome FULLSCREEN_FLOWS, quindi
+          {/* ── Table ───────────────────────────────────────────────── */}
+          {/* La pagina /positions è in MainChrome FULLSCREEN_FLOWS, quindi
           il main è già full-width con padding 48px. La tabella prende
           100% e ha scroll-x se eccede. */}
-      <div className="overflow-x-auto border border-[var(--color-border)] rounded-lg">
-        <table
-          className="w-full text-[12px]"
-          style={{ borderCollapse: "collapse" }}
-          aria-label="Lista posizioni"
-        >
-          <thead>
-            <tr className="bg-[var(--color-panel)] border-b border-[var(--color-border)]">
-              {[
-                { col: "found_at", label: "Rilevata" },
-                { col: "id", label: "ID" },
-                { col: "title", label: "Titolo" },
-                { col: "company", label: "Azienda" },
-                { col: "source", label: "Fonte" },
-                { col: "location", label: "Location" },
-                { col: "score", label: "Score" },
-                { col: "status", label: "Stato" },
-                { col: "critic", label: "Voto finale" },
-              ].map(({ col, label }) => (
-                <th
-                  key={col}
-                  scope="col"
-                  className="px-4 py-3 text-left text-[9.5px] font-semibold tracking-[0.15em] uppercase whitespace-nowrap"
-                  style={{
-                    color:
-                      sortCol === col
-                        ? "var(--color-bright)"
-                        : "var(--color-dim)",
-                  }}
-                >
-                  <span className="inline-flex items-center gap-1.5">
-                    <Link
-                      href={sortHref(col)}
-                      className="no-underline hover:text-[var(--color-green)] transition-colors"
-                      style={{ color: "inherit" }}
-                    >
-                      {label}
-                      <span aria-hidden="true">{sortIndicator(col)}</span>
-                    </Link>
-                    {EXPANDABLE_COLUMNS.has(col) && (
-                      <Link
-                        href={expandHref(col)}
-                        title={
-                          isExpanded(col)
-                            ? "Comprimi colonna"
-                            : "Espandi colonna"
-                        }
-                        aria-label={
-                          isExpanded(col)
-                            ? "Comprimi colonna"
-                            : "Espandi colonna"
-                        }
-                        className="no-underline text-[10px] leading-none px-1 rounded hover:bg-[var(--color-card)] hover:text-[var(--color-green)] transition-colors"
-                        style={{
-                          color: isExpanded(col)
-                            ? "var(--color-green)"
-                            : "var(--color-dim)",
-                        }}
-                      >
-                        {isExpanded(col) ? "⇲" : "⇱"}
-                      </Link>
-                    )}
-                  </span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {visiblePositions.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={9}
-                  className="px-4 py-12 text-center text-[var(--color-dim)] text-[11px]"
-                >
-                  Nessuna posizione trovata con questi filtri.
-                </td>
-              </tr>
-            ) : (
-              visiblePositions.map((p: PositionWithScore, i: number) => (
-                <tr
-                  key={p.id}
-                  className="border-b border-[var(--color-border)] hover:bg-[var(--color-row)] transition-colors"
-                  style={{
-                    borderBottomColor:
-                      i === visiblePositions.length - 1
-                        ? "transparent"
-                        : undefined,
-                    background:
-                      i % 2 === 1 ? "rgba(255,255,255,0.008)" : undefined,
-                  }}
-                >
-                  <td className="px-4 py-3 text-[10px] text-[var(--color-muted)] whitespace-nowrap font-mono">
-                    {formatFoundAt(p.found_at)}
-                  </td>
-                  <td className="px-4 py-3 text-[10px] text-[var(--color-dim)] whitespace-nowrap">
-                    <span className="inline-flex items-center gap-1.5">
-                      {p.legacy_id
-                        ? `JHT-${String(p.legacy_id).padStart(3, "0")}`
-                        : p.id.slice(0, 8)}
-                      {p.legacy_id != null && syncedIds.has(p.legacy_id) && (
-                        <span
-                          title="Sincronizzato sul cloud"
-                          aria-label="Sincronizzato sul cloud"
-                          style={{
-                            color: "var(--color-green)",
-                            fontSize: "11px",
-                            lineHeight: 1,
-                          }}
-                        >
-                          ☁
-                        </span>
-                      )}
-                    </span>
-                  </td>
-                  <td
-                    className={`px-4 py-3 font-medium ${
-                      isExpanded("title") ? "" : "max-w-[220px]"
-                    }`}
-                  >
-                    <Link
-                      href={`/positions/${p.id}`}
-                      className={`text-[var(--color-bright)] hover:text-[var(--color-green)] no-underline transition-colors ${
-                        isExpanded("title") ? "" : "line-clamp-2"
-                      }`}
-                    >
-                      {p.title}
-                    </Link>
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-[var(--color-base)] ${
-                      isExpanded("company")
-                        ? "whitespace-normal"
-                        : "whitespace-nowrap max-w-[140px] truncate"
-                    }`}
-                    title={p.company}
-                  >
-                    {p.company}
-                  </td>
-                  <td className="px-4 py-3 text-[10px] text-[var(--color-muted)] whitespace-nowrap font-mono">
-                    {p.source ?? "—"}
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-[11px] text-[var(--color-muted)] ${
-                      isExpanded("location")
-                        ? "whitespace-normal"
-                        : "max-w-[200px] truncate whitespace-nowrap"
-                    }`}
-                    title={p.location ?? undefined}
-                  >
-                    {p.location ?? "—"}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2 justify-end">
-                      <span
-                        className={`text-[12px] font-semibold w-6 text-right ${scoreClass(p.score)}`}
-                      >
-                        {p.score ?? "—"}
-                      </span>
-                      <div
-                        className="w-10 h-1 rounded-full overflow-hidden"
-                        style={{ background: "var(--color-border)" }}
-                      >
-                        <div
-                          className="h-full rounded-full"
-                          style={{
-                            width: `${p.score ?? 0}%`,
-                            background: scoreBg(p.score),
-                          }}
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className="text-[9.5px] font-semibold px-2 py-0.5 rounded-full border whitespace-nowrap"
+          <div className="overflow-x-auto border border-[var(--color-border)] rounded-lg">
+            <table
+              className="w-full text-[12px]"
+              style={{ borderCollapse: "collapse" }}
+              aria-label="Lista posizioni"
+            >
+              <thead>
+                <tr className="bg-[var(--color-panel)] border-b border-[var(--color-border)]">
+                  {[
+                    { col: "found_at", label: "Rilevata" },
+                    { col: "id", label: "ID" },
+                    { col: "title", label: "Titolo" },
+                    { col: "company", label: "Azienda" },
+                    { col: "source", label: "Fonte" },
+                    { col: "location", label: "Location" },
+                    { col: "score", label: "Score" },
+                    { col: "status", label: "Stato" },
+                    { col: "critic", label: "Voto finale" },
+                  ].map(({ col, label }) => (
+                    <th
+                      key={col}
+                      scope="col"
+                      className="px-4 py-3 text-left text-[9.5px] font-semibold tracking-[0.15em] uppercase whitespace-nowrap"
                       style={{
-                        color: STATUS_COLORS[p.status] ?? "var(--color-dim)",
-                        borderColor:
-                          STATUS_COLORS[p.status] ?? "var(--color-border)",
-                        background: `${STATUS_COLORS[p.status]}18`,
+                        color:
+                          sortCol === col
+                            ? "var(--color-bright)"
+                            : "var(--color-dim)",
                       }}
                     >
-                      {p.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    {p.critic_score != null || p.critic_verdict ? (
-                      <div className="flex items-center gap-2">
-                        <span
-                          className="text-[12px] font-semibold tabular-nums"
-                          style={{
-                            color:
-                              CRITIC_COLORS[p.critic_verdict ?? ""] ??
-                              "var(--color-muted)",
-                          }}
+                      <span className="inline-flex items-center gap-1.5">
+                        <Link
+                          href={sortHref(col)}
+                          className="no-underline hover:text-[var(--color-green)] transition-colors"
+                          style={{ color: "inherit" }}
                         >
-                          {p.critic_score != null
-                            ? p.critic_score.toFixed(1)
-                            : "—"}
-                        </span>
-                        {p.critic_verdict && (
-                          <span
-                            className="text-[9px] font-semibold tracking-[0.1em] uppercase px-1.5 py-0.5 rounded border"
+                          {label}
+                          <span aria-hidden="true">{sortIndicator(col)}</span>
+                        </Link>
+                        {EXPANDABLE_COLUMNS.has(col) && (
+                          <Link
+                            href={expandHref(col)}
+                            title={
+                              isExpanded(col)
+                                ? "Comprimi colonna"
+                                : "Espandi colonna"
+                            }
+                            aria-label={
+                              isExpanded(col)
+                                ? "Comprimi colonna"
+                                : "Espandi colonna"
+                            }
+                            className="no-underline text-[10px] leading-none px-1 rounded hover:bg-[var(--color-card)] hover:text-[var(--color-green)] transition-colors"
                             style={{
-                              color:
-                                CRITIC_COLORS[p.critic_verdict] ??
-                                "var(--color-dim)",
-                              borderColor:
-                                CRITIC_COLORS[p.critic_verdict] ??
-                                "var(--color-border)",
-                              background: `${CRITIC_COLORS[p.critic_verdict] ?? "var(--color-border)"}18`,
+                              color: isExpanded(col)
+                                ? "var(--color-green)"
+                                : "var(--color-dim)",
                             }}
                           >
-                            {p.critic_verdict.replace("_", " ")}
+                            {isExpanded(col) ? "⇲" : "⇱"}
+                          </Link>
+                        )}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {visiblePositions.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={9}
+                      className="px-4 py-12 text-center text-[var(--color-dim)] text-[11px]"
+                    >
+                      Nessuna posizione trovata con questi filtri.
+                    </td>
+                  </tr>
+                ) : (
+                  visiblePositions.map((p: PositionWithScore, i: number) => (
+                    <tr
+                      key={p.id}
+                      className="border-b border-[var(--color-border)] hover:bg-[var(--color-row)] transition-colors"
+                      style={{
+                        borderBottomColor:
+                          i === visiblePositions.length - 1
+                            ? "transparent"
+                            : undefined,
+                        background:
+                          i % 2 === 1 ? "rgba(255,255,255,0.008)" : undefined,
+                      }}
+                    >
+                      <td className="px-4 py-3 text-[10px] text-[var(--color-muted)] whitespace-nowrap font-mono">
+                        {formatFoundAt(p.found_at)}
+                      </td>
+                      <td className="px-4 py-3 text-[10px] text-[var(--color-dim)] whitespace-nowrap">
+                        <span className="inline-flex items-center gap-1.5">
+                          {p.legacy_id
+                            ? `JHT-${String(p.legacy_id).padStart(3, "0")}`
+                            : p.id.slice(0, 8)}
+                          {p.legacy_id != null &&
+                            syncedIds.has(p.legacy_id) && (
+                              <span
+                                title="Sincronizzato sul cloud"
+                                aria-label="Sincronizzato sul cloud"
+                                style={{
+                                  color: "var(--color-green)",
+                                  fontSize: "11px",
+                                  lineHeight: 1,
+                                }}
+                              >
+                                ☁
+                              </span>
+                            )}
+                        </span>
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-medium ${
+                          isExpanded("title") ? "" : "max-w-[220px]"
+                        }`}
+                      >
+                        <Link
+                          href={`/positions/${p.id}`}
+                          className={`text-[var(--color-bright)] hover:text-[var(--color-green)] no-underline transition-colors ${
+                            isExpanded("title") ? "" : "line-clamp-2"
+                          }`}
+                        >
+                          {p.title}
+                        </Link>
+                      </td>
+                      <td
+                        className={`px-4 py-3 text-[var(--color-base)] ${
+                          isExpanded("company")
+                            ? "whitespace-normal"
+                            : "whitespace-nowrap max-w-[140px] truncate"
+                        }`}
+                        title={p.company}
+                      >
+                        {p.company}
+                      </td>
+                      <td className="px-4 py-3 text-[10px] text-[var(--color-muted)] whitespace-nowrap font-mono">
+                        {p.source ?? "—"}
+                      </td>
+                      <td
+                        className={`px-4 py-3 text-[11px] text-[var(--color-muted)] ${
+                          isExpanded("location")
+                            ? "whitespace-normal"
+                            : "max-w-[200px] truncate whitespace-nowrap"
+                        }`}
+                        title={p.location ?? undefined}
+                      >
+                        {p.location ?? "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2 justify-end">
+                          <span
+                            className={`text-[12px] font-semibold w-6 text-right ${scoreClass(p.score)}`}
+                          >
+                            {p.score ?? "—"}
+                          </span>
+                          <div
+                            className="w-10 h-1 rounded-full overflow-hidden"
+                            style={{ background: "var(--color-border)" }}
+                          >
+                            <div
+                              className="h-full rounded-full"
+                              style={{
+                                width: `${p.score ?? 0}%`,
+                                background: scoreBg(p.score),
+                              }}
+                            />
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className="text-[9.5px] font-semibold px-2 py-0.5 rounded-full border whitespace-nowrap"
+                          style={{
+                            color:
+                              STATUS_COLORS[p.status] ?? "var(--color-dim)",
+                            borderColor:
+                              STATUS_COLORS[p.status] ?? "var(--color-border)",
+                            background: `${STATUS_COLORS[p.status]}18`,
+                          }}
+                        >
+                          {p.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        {p.critic_score != null || p.critic_verdict ? (
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="text-[12px] font-semibold tabular-nums"
+                              style={{
+                                color:
+                                  CRITIC_COLORS[p.critic_verdict ?? ""] ??
+                                  "var(--color-muted)",
+                              }}
+                            >
+                              {p.critic_score != null
+                                ? p.critic_score.toFixed(1)
+                                : "—"}
+                            </span>
+                            {p.critic_verdict && (
+                              <span
+                                className="text-[9px] font-semibold tracking-[0.1em] uppercase px-1.5 py-0.5 rounded border"
+                                style={{
+                                  color:
+                                    CRITIC_COLORS[p.critic_verdict] ??
+                                    "var(--color-dim)",
+                                  borderColor:
+                                    CRITIC_COLORS[p.critic_verdict] ??
+                                    "var(--color-border)",
+                                  background: `${CRITIC_COLORS[p.critic_verdict] ?? "var(--color-border)"}18`,
+                                }}
+                              >
+                                {p.critic_verdict.replace("_", " ")}
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-[var(--color-dim)] text-[11px]">
+                            —
                           </span>
                         )}
-                      </div>
-                    ) : (
-                      <span className="text-[var(--color-dim)] text-[11px]">
-                        —
-                      </span>
-                    )}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* ── Pagination ──────────────────────────────────────────── */}
-      <div className="flex flex-wrap items-center justify-between gap-3 mt-4 text-[11px] text-[var(--color-muted)]">
-        <div>
-          {totalResults === 0
-            ? "0 risultati"
-            : `${startIdx + 1}–${Math.min(startIdx + pageSize, totalResults)} di ${totalResults} · pagina ${page} / ${pageCount}`}
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="flex items-center gap-1">
-            {page > 1 ? (
-              <Link
-                href={buildHref({ page: String(page - 1) })}
-                className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] hover:border-[var(--color-green)] hover:text-[var(--color-green)] transition-colors no-underline text-[var(--color-base)]"
-              >
-                ← Precedenti
-              </Link>
-            ) : (
-              <span className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] text-[var(--color-dim)] opacity-50">
-                ← Precedenti
-              </span>
-            )}
-            {page < pageCount ? (
-              <Link
-                href={buildHref({ page: String(page + 1) })}
-                className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] hover:border-[var(--color-green)] hover:text-[var(--color-green)] transition-colors no-underline text-[var(--color-base)]"
-              >
-                Successivi →
-              </Link>
-            ) : (
-              <span className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] text-[var(--color-dim)] opacity-50">
-                Successivi →
-              </span>
-            )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
           </div>
-        </div>
-      </div>
+
+          {/* ── Pagination ──────────────────────────────────────────── */}
+          <div className="flex flex-wrap items-center justify-between gap-3 mt-4 text-[11px] text-[var(--color-muted)]">
+            <div>
+              {totalResults === 0
+                ? "0 risultati"
+                : `${startIdx + 1}–${Math.min(startIdx + pageSize, totalResults)} di ${totalResults} · pagina ${page} / ${pageCount}`}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-1">
+                {page > 1 ? (
+                  <Link
+                    href={buildHref({ page: String(page - 1) })}
+                    className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] hover:border-[var(--color-green)] hover:text-[var(--color-green)] transition-colors no-underline text-[var(--color-base)]"
+                  >
+                    ← Precedenti
+                  </Link>
+                ) : (
+                  <span className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] text-[var(--color-dim)] opacity-50">
+                    ← Precedenti
+                  </span>
+                )}
+                {page < pageCount ? (
+                  <Link
+                    href={buildHref({ page: String(page + 1) })}
+                    className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] hover:border-[var(--color-green)] hover:text-[var(--color-green)] transition-colors no-underline text-[var(--color-base)]"
+                  >
+                    Successivi →
+                  </Link>
+                ) : (
+                  <span className="px-3 py-1 text-[10px] font-semibold rounded border border-[var(--color-border)] text-[var(--color-dim)] opacity-50">
+                    Successivi →
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/web/app/(protected)/profile/page.tsx
+++ b/web/app/(protected)/profile/page.tsx
@@ -217,7 +217,10 @@ export default async function ProfilePage() {
             {/* Basic Info */}
             <ProfileSection id="info-base" title={t("sec_info_base")}>
               <ProfileField label={t("f_name")} value={profile.name} />
-              <ProfileField label={t("f_target_role")} value={profile.target_role} />
+              <ProfileField
+                label={t("f_target_role")}
+                value={profile.target_role}
+              />
               <ProfileField label={t("f_location")} value={profile.location} />
               <ProfileField
                 label={t("f_experience")}
@@ -731,7 +734,10 @@ export default async function ProfilePage() {
             </ProfileSection>
 
             {/* Obiettivi di carriera */}
-            <ProfileSection id="obiettivi-carriera" title={t("sec_career_goals")}>
+            <ProfileSection
+              id="obiettivi-carriera"
+              title={t("sec_career_goals")}
+            >
               {hasCareerGoals ? (
                 <div className="flex flex-col gap-2">
                   <ProfileField

--- a/web/app/api/case-studies/route.ts
+++ b/web/app/api/case-studies/route.ts
@@ -7,8 +7,6 @@
 // Response shape is stable: { caseStudies: [...], coverage: [...] }.
 
 import { NextResponse } from "next/server";
-// @ts-expect-error node:sqlite richiede Node 22.5+ — runtime ok su Vercel/dev,
-// types @types/node attuali non lo dichiarano. Quando aggiorniamo @types/node si rimuove.
 import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import fs from "node:fs";


### PR DESCRIPTION
Porta il CI a verde dopo il riallineamento di master.

## Fix
- **Type-check / Build Web**: rimosso `@ts-expect-error` su `node:sqlite` in `web/app/api/case-studies/route.ts` — `@types/node` è ora 24.x e dichiara `node:sqlite`, quindi la direttiva era inutilizzata (TS2578) e faceva fallire `tsc --noEmit` + `next build`. Il commento stesso prevedeva la rimozione all'aggiornamento di @types/node.
- **Prettier (web/app/ + shared/)**: riformattati 3 file (`positions/page.tsx`, `PositionsFilterSidebar.tsx`, `profile/page.tsx`) con prettier 3.8.3 (stessa versione del CI).

## Verifica locale
- `prettier --check` (scope CI): All matched files use Prettier code style ✅
- `tsc --noEmit`: 0 errori ✅
- `eslint`: 0 errori (solo warning) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)