### PR TITLE
fix(cli/cloud): realtime-listen import al file rinominato (ERR_MODULE_NOT_FOUND)

### DIFF
--- a/cli/src/commands/cloud.js
+++ b/cli/src/commands/cloud.js
@@ -1661,8 +1661,8 @@ export function registerCloudCommand(program) {
     .command('realtime-listen')
     .description('Subscriber Realtime per comandi team (start/stop) dal web')
     .action(async () => {
-      const { runRealtimeSubscriber } = await import('../lib/realtime-subscriber.js');
-      await runRealtimeSubscriber();
+      const { runTeamCommandsPoller } = await import('../lib/team-commands-poller.js');
+      await runTeamCommandsPoller();
     });
 
   // `team-state-listen` — desired-state reconciler che polla /api/team-state


### PR DESCRIPTION
## Bug
Il cloud daemon falliva con `ERR_MODULE_NOT_FOUND: cli/src/lib/realtime-subscriber.js`. Il refactor che ha rinominato `realtime-subscriber.js` → `team-commands-poller.js` aveva lasciato un import dinamico stale (path + funzione) in `cloud.js` (comando `realtime-listen`), spezzando il canale comandi web→team (Start/Stop dal sito + enforcement realtime del weekly-halt).

## Fix
`cloud.js:1664`: `runRealtimeSubscriber` da `'../lib/realtime-subscriber.js'` → `runTeamCommandsPoller` da `'../lib/team-commands-poller.js'`.

Bug pre-esistente (non in v0.1.18). Scoperto aggiornando la VPS beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)