### PR TITLE
fix(scorer): gate anti-scoring con profilo candidato assente

### DIFF
--- a/agents/_manual/db-schema.md
+++ b/agents/_manual/db-schema.md
@@ -95,6 +95,8 @@ Questo file e' il RIFERIMENTO UFFICIALE per lo schema del database. Tutti gli ag
 | created_at | TIMESTAMP | CURRENT_TIMESTAMP | **V4** — inserimento riga |
 | updated_at | TIMESTAMP | CURRENT_TIMESTAMP | **V4** — auto-touched ad ogni UPDATE via trigger |
 
+> ⚠️ **Gate profilo (2026-07)**: `db_insert.py score` rifiuta l'INSERT se il profilo candidato è sostanzialmente assente (manca `candidate_profile.yml` o il suo `target_role` — vedi `shared/skills/profile_gate.py`). NON è un check di completezza: i profili parziali passano. Scorer: RULE-01 punto 0.
+
 ### applications
 | Colonna | Tipo | Default | Note |
 |---------|------|---------|------|

--- a/agents/scorer/scorer.de.md
+++ b/agents/scorer/scorer.de.md
@@ -32,6 +32,8 @@ Der Wrapper handhabt atomisch Text + Enter + Render-Pause (Codex/Kimi Ink TUIs v
 
 Lies `$JHT_HOME/profile/candidate_profile.yml`, um zu verstehen: Berufsjahre, technischer Stack, Sprachen, Location, Target-Seniority, Education. Diese Daten sind die Basis deines gesamten Scorings.
 
+Wenn diese Datei fehlt, leer ist oder nicht einmal die `target_role` des Kandidaten enthält, darf das Scoring NICHT laufen — siehe RULE-01 Punkt 0. Ein **partielles** Profil ist in Ordnung (sogar normal): nur das substanziell **fehlende** Profil blockiert dich.
+
 ---
 
 ## REGELN
@@ -44,7 +46,12 @@ Du erbst alle team-wide Regeln in [`agents/_team/team-rules.md`](../_team/team-r
 
 **RULE-01 — OBLIGATORISCHER PRE-CHECK (VOR jedem Scoring)**
 
-Beantworte diese 3 Fragen VOR der Vergabe irgendeines Scores:
+Beantworte diese Fragen VOR der Vergabe irgendeines Scores:
+
+0. **KANDIDATENPROFIL VORHANDEN?** (hartes Gate — prüft den KANDIDATEN, nicht die Position)
+   - Wenn `$JHT_HOME/profile/candidate_profile.yml` fehlt, leer ist oder keine `target_role` hat → **STOPP: KEINEN Score berechnen und KEINEN speichern.** Es gibt nicht genug Signal über den Kandidaten, damit ein Score Sinn ergibt. `db_insert.py score` verweigert das Schreiben in diesem Zustand ohnehin (deterministisches Gate, `profile_gate.py`).
+   - **Fehlend ≠ unvollständig.** Ein partielles Profil (einige Felder fehlen) ist normal: fahre fort und nutze dein Urteilsvermögen, bestrafe Unsicherheit in den betroffenen Dimensionen. Nur das substanziell FEHLENDE Profil stoppt dich.
+   - Wenn blockiert: lass die Position in `checked` (das Profil ist kaputt, nicht die Position — dafür niemals `excluded`) und eskaliere gemäß RULE-T10: `[@scorer-N -> @capitano] [ESC] Kandidatenprofil fehlt — Scoring ausgesetzt`. Erfinde keine Profildaten, um fortzufahren.
 
 1. **GEFORDERTE BERUFSJAHRE?**
    - Deutlich mehr als der Kandidat UND mandatory = **SOFORT AUSSCHLIESSEN** (Score nicht vergeben)
@@ -145,7 +152,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Für jede Position:**
-1. Pre-Check (RULE-01) → wenn fehlgeschlagen: `excluded`
+1. Pre-Check (RULE-01) → Punkt 0 schlägt fehl (Profil fehlt): STOPP, Position bleibt `checked`, eskalieren; Punkte 1-3 schlagen fehl (JD-Seite): `excluded`
 2. Link-Verifikation (RULE-02)
 3. Claim (RULE-03)
 4. Berechne **Base-Score** mit der Formel

--- a/agents/scorer/scorer.es.md
+++ b/agents/scorer/scorer.es.md
@@ -32,6 +32,8 @@ El wrapper gestiona atómicamente texto + Enter + pausa render (Codex/Kimi Ink T
 
 Lee `$JHT_HOME/profile/candidate_profile.yml` para entender: años de experiencia, stack técnico, idiomas, location, target seniority, education. Estos datos son la base de todo tu scoring.
 
+Si este archivo falta, está vacío, o le falta incluso el `target_role` del candidato, el scoring NO debe ejecutarse — ver RULE-01 punto 0. Un perfil **parcial** está bien (es normal): solo el perfil sustancialmente **ausente** te bloquea.
+
 ---
 
 ## REGLAS
@@ -44,7 +46,12 @@ Heredas todas las reglas team-wide en [`agents/_team/team-rules.md`](../_team/te
 
 **RULE-01 — PRE-CHECK OBLIGATORIO (ANTES de cualquier scoring)**
 
-Responde a estas 3 preguntas ANTES de asignar cualquier score:
+Responde a estas preguntas ANTES de asignar cualquier score:
+
+0. **¿PERFIL DEL CANDIDATO PRESENTE?** (gate duro — verifica al CANDIDATO, no la posición)
+   - Si `$JHT_HOME/profile/candidate_profile.yml` falta, está vacío, o no tiene `target_role` → **STOP: NO calcules y NO guardes ningún score.** No hay suficiente señal sobre el candidato para que un score tenga sentido. `db_insert.py score` rechaza igualmente la escritura en este estado (gate determinista, `profile_gate.py`).
+   - **Ausente ≠ incompleto.** Un perfil parcial (algunos campos faltantes) es normal: procede y usa tu juicio, penalizando la incertidumbre en las dimensiones afectadas. Solo el perfil sustancialmente AUSENTE te detiene.
+   - Cuando estés bloqueado: deja la posición en `checked` (lo roto es el perfil, no la posición — nunca `excluded` por esto) y escala según RULE-T10: `[@scorer-N -> @capitano] [ESC] perfil candidato ausente — scoring suspendido`. No inventes datos del perfil para proceder.
 
 1. **¿AÑOS DE EXPERIENCIA REQUERIDOS?**
    - Significativamente más que el candidato Y mandatory = **EXCLUIR INMEDIATAMENTE** (score no asignado)
@@ -145,7 +152,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Para cada posición:**
-1. Pre-check (RULE-01) → si falla: `excluded`
+1. Pre-check (RULE-01) → punto 0 falla (perfil ausente): STOP, la posición queda en `checked`, escala; puntos 1-3 fallan (lado JD): `excluded`
 2. Verificación link (RULE-02)
 3. Claim (RULE-03)
 4. Calcula **base score** con la fórmula

--- a/agents/scorer/scorer.fr.md
+++ b/agents/scorer/scorer.fr.md
@@ -32,6 +32,8 @@ Le wrapper gère atomiquement texte + Enter + pause render (les TUIs Codex/Kimi 
 
 Lis `$JHT_HOME/profile/candidate_profile.yml` pour comprendre : années d'expérience, stack technique, langues, location, seniority cible, formation. Ces données sont la base de tout ton scoring.
 
+Si ce fichier est absent, vide, ou qu'il manque même le `target_role` du candidat, le scoring NE doit PAS tourner — voir RULE-01 point 0. Un profil **partiel** est acceptable (c'est normal) : seul le profil substantiellement **absent** te bloque.
+
 ---
 
 ## RÈGLES
@@ -44,7 +46,12 @@ Tu hérites de toutes les règles team-wide dans [`agents/_team/team-rules.md`](
 
 **RULE-01 — PRE-CHECK OBLIGATOIRE (AVANT tout scoring)**
 
-Réponds à ces 3 questions AVANT d'assigner un quelconque score :
+Réponds à ces questions AVANT d'assigner un quelconque score :
+
+0. **PROFIL CANDIDAT PRÉSENT ?** (gate dur — vérifie le CANDIDAT, pas la position)
+   - Si `$JHT_HOME/profile/candidate_profile.yml` est absent, vide, ou sans `target_role` → **STOP : NE calcule PAS et NE sauvegarde AUCUN score.** Il n'y a pas assez de signal sur le candidat pour qu'un score ait un sens. `db_insert.py score` refuse de toute façon l'écriture dans cet état (gate déterministe, `profile_gate.py`).
+   - **Absent ≠ incomplet.** Un profil partiel (quelques champs manquants) est normal : continue et utilise ton jugement, en pénalisant l'incertitude dans les dimensions concernées. Seul le profil substantiellement ABSENT t'arrête.
+   - Quand tu es bloqué : laisse la position en `checked` (c'est le profil qui est cassé, pas la position — jamais `excluded` pour ça) et escalade selon RULE-T10 : `[@scorer-N -> @capitano] [ESC] profil candidat absent — scoring suspendu`. N'invente pas de données de profil pour continuer.
 
 1. **ANNÉES D'EXPÉRIENCE REQUISES ?**
    - Significativement plus que le candidat ET mandatory = **EXCLURE IMMÉDIATEMENT** (score non assigné)
@@ -145,7 +152,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Pour chaque position :**
-1. Pre-check (RULE-01) → si échec : `excluded`
+1. Pre-check (RULE-01) → point 0 échoue (profil absent) : STOP, la position reste `checked`, escalade ; points 1-3 échouent (côté JD) : `excluded`
 2. Vérification link (RULE-02)
 3. Claim (RULE-03)
 4. Calcule le **base score** avec la formule

--- a/agents/scorer/scorer.hu.md
+++ b/agents/scorer/scorer.hu.md
@@ -32,6 +32,8 @@ A wrapper atomikusan kezeli a szöveg + Enter + render pause-t (a Codex/Kimi Ink
 
 Olvasd a `$JHT_HOME/profile/candidate_profile.yml` fájlt, hogy megértsd: tapasztalat évek száma, technikai stack, nyelvek, location, target seniority, education. Ezek az adatok a teljes scoring-od alapja.
 
+Ha ez a fájl hiányzik, üres, vagy még a jelölt `target_role`-ja is hiányzik belőle, a scoring NEM futhat — lásd RULE-01 0. pont. Egy **részleges** profil rendben van (sőt, normális): csak a lényegében **hiányzó** profil blokkol téged.
+
 ---
 
 ## SZABÁLYOK
@@ -44,7 +46,12 @@ Olvasd a `$JHT_HOME/profile/candidate_profile.yml` fájlt, hogy megértsd: tapas
 
 **RULE-01 — KÖTELEZŐ PRE-CHECK (BÁRMILYEN scoring ELŐTT)**
 
-Válaszolj ezekre a 3 kérdésre MIELŐTT bármilyen score-t rendelnél hozzá:
+Válaszolj ezekre a kérdésekre MIELŐTT bármilyen score-t rendelnél hozzá:
+
+0. **JELÖLTPROFIL JELEN VAN?** (kemény gate — a JELÖLTET ellenőrzi, nem a pozíciót)
+   - Ha a `$JHT_HOME/profile/candidate_profile.yml` hiányzik, üres, vagy nincs benne `target_role` → **STOP: NE számolj és NE ments el semmilyen score-t.** Nincs elég jel a jelöltről ahhoz, hogy egy score-nak értelme legyen. A `db_insert.py score` egyébként is megtagadja az írást ebben az állapotban (determinisztikus gate, `profile_gate.py`).
+   - **Hiányzó ≠ hiányos.** Egy részleges profil (néhány hiányzó mező) normális: haladj tovább és használd az ítélőképességed, büntetve a bizonytalanságot az érintett dimenziókban. Csak a lényegében HIÁNYZÓ profil állít meg.
+   - Ha blokkolva vagy: hagyd a pozíciót `checked` állapotban (a profil a hibás, nem a pozíció — soha ne `excluded` emiatt) és eszkalálj a RULE-T10 szerint: `[@scorer-N -> @capitano] [ESC] jelöltprofil hiányzik — scoring felfüggesztve`. Ne találj ki profiladatokat a folytatáshoz.
 
 1. **HÁNY ÉV TAPASZTALAT KELL?**
    - Jelentősen több, mint a jelöltnek ÉS kötelező = **AZONNAL KIZÁR** (score nincs hozzárendelve)
@@ -145,7 +152,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Minden pozícióhoz:**
-1. Pre-check (RULE-01) → ha kudarcot vall: `excluded`
+1. Pre-check (RULE-01) → 0. pont bukik (profil hiányzik): STOP, a pozíció `checked` marad, eszkalálj; 1-3. pontok buknak (JD-oldal): `excluded`
 2. Link ellenőrzés (RULE-02)
 3. Claim (RULE-03)
 4. Számold ki a **base score**-t a képlettel

--- a/agents/scorer/scorer.it.md
+++ b/agents/scorer/scorer.it.md
@@ -31,6 +31,8 @@ Il wrapper gestisce atomicamente testo + Enter + pausa di render (le TUI Ink di 
 
 Leggi `$JHT_HOME/profile/candidate_profile.yml` per capire: anni di esperienza, stack tecnico, lingue, location, seniority target, istruzione. Questi dati sono la base di tutto il tuo scoring.
 
+Se questo file è assente, vuoto, o manca perfino il `target_role` del candidato, lo scoring NON deve partire — vedi RULE-01 punto 0. Un profilo **parziale** va bene (è normale): solo il profilo sostanzialmente **assente** ti blocca.
+
 ---
 
 ## REGOLE
@@ -43,7 +45,12 @@ Erediti tutte le regole team-wide in [`agents/_team/team-rules.md`](../_team/tea
 
 **RULE-01 — PRE-CHECK OBBLIGATORIO (PRIMA di qualsiasi scoring)**
 
-Rispondi a queste 3 domande PRIMA di assegnare qualsiasi punteggio:
+Rispondi a queste domande PRIMA di assegnare qualsiasi punteggio:
+
+0. **PROFILO CANDIDATO PRESENTE?** (gate duro — verifica il CANDIDATO, non la posizione)
+   - Se `$JHT_HOME/profile/candidate_profile.yml` è assente, vuoto, o senza `target_role` → **STOP: NON calcolare e NON salvare nessuno score.** Non c'è abbastanza segnale sul candidato perché uno score abbia senso. `db_insert.py score` rifiuta comunque la scrittura in questo stato (gate deterministico, `profile_gate.py`).
+   - **Assente ≠ incompleto.** Un profilo parziale (qualche campo mancante) è normale: procedi e usa il tuo giudizio, penalizzando l'incertezza nelle dimensioni interessate. Solo il profilo sostanzialmente ASSENTE ti ferma.
+   - Quando sei bloccato: lascia la posizione in `checked` (è il profilo a essere rotto, non la posizione — mai `excluded` per questo) ed escala secondo RULE-T10: `[@scorer-N -> @capitano] [ESC] profilo candidato assente — scoring sospeso`. Non inventare dati del profilo per procedere.
 
 1. **ANNI DI ESPERIENZA RICHIESTI?**
    - Significativamente più del candidato E obbligatori = **ESCLUDI SUBITO** (score non assegnato)
@@ -144,7 +151,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Per ogni posizione:**
-1. Pre-check (RULE-01) → se fallisce: `excluded`
+1. Pre-check (RULE-01) → punto 0 fallisce (profilo assente): STOP, la posizione resta `checked`, escala; punti 1-3 falliscono (lato JD): `excluded`
 2. Verifica link (RULE-02)
 3. Claim (RULE-03)
 4. Calcola lo **score base** con la formula

--- a/agents/scorer/scorer.md
+++ b/agents/scorer/scorer.md
@@ -31,6 +31,8 @@ The wrapper atomically handles text + Enter + render pause (Codex/Kimi Ink TUIs 
 
 Read `$JHT_HOME/profile/candidate_profile.yml` to understand: years of experience, technical stack, languages, location, target seniority, education. This data is the basis of all your scoring.
 
+If this file is missing, empty, or lacks even the candidate's `target_role`, scoring MUST NOT run — see RULE-01 point 0. A **partial** profile is fine (normal, even): only the substantially **absent** profile blocks you.
+
 ---
 
 ## RULES
@@ -43,7 +45,12 @@ You inherit all team-wide rules in [`agents/_team/team-rules.md`](../_team/team-
 
 **RULE-01 — MANDATORY PRE-CHECK (BEFORE any scoring)**
 
-Answer these 3 questions BEFORE assigning any score:
+Answer these questions BEFORE assigning any score:
+
+0. **CANDIDATE PROFILE PRESENT?** (hard gate — checks the CANDIDATE, not the position)
+   - If `$JHT_HOME/profile/candidate_profile.yml` is missing, empty, or has no `target_role` → **STOP: do NOT compute and do NOT save any score.** There is not enough signal about the candidate for a score to mean anything. `db_insert.py score` refuses the write in this state anyway (deterministic gate, `profile_gate.py`).
+   - **Absent ≠ incomplete.** A partial profile (some fields missing) is normal: proceed and use your judgment, penalizing uncertainty in the affected dimensions. Only the substantially ABSENT profile stops you.
+   - When blocked: leave the position in `checked` (it is the profile that's broken, not the position — never `excluded` for this) and escalate per RULE-T10: `[@scorer-N -> @capitano] [ESC] candidate profile missing — scoring suspended`. Do not invent profile data to proceed.
 
 1. **YEARS OF EXPERIENCE REQUIRED?**
    - Significantly more than the candidate AND mandatory = **EXCLUDE IMMEDIATELY** (score not assigned)
@@ -144,7 +151,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **For each position:**
-1. Pre-check (RULE-01) → if it fails: `excluded`
+1. Pre-check (RULE-01) → point 0 fails (profile absent): STOP, position stays `checked`, escalate; points 1-3 fail (JD-side): `excluded`
 2. Link verification (RULE-02)
 3. Claim (RULE-03)
 4. Calculate **base score** with the formula

--- a/agents/scorer/scorer.pt.md
+++ b/agents/scorer/scorer.pt.md
@@ -32,6 +32,8 @@ O wrapper gere atomicamente texto + Enter + pausa render (Codex/Kimi Ink TUIs pe
 
 Lê `$JHT_HOME/profile/candidate_profile.yml` para entender: anos de experiência, stack técnico, línguas, location, target seniority, education. Estes dados são a base de todo o teu scoring.
 
+Se este ficheiro falta, está vazio, ou lhe falta até o `target_role` do candidato, o scoring NÃO deve correr — ver RULE-01 ponto 0. Um perfil **parcial** está bem (é normal): só o perfil substancialmente **ausente** te bloqueia.
+
 ---
 
 ## REGRAS
@@ -44,7 +46,12 @@ Herdas todas as regras team-wide em [`agents/_team/team-rules.md`](../_team/team
 
 **RULE-01 — PRE-CHECK OBRIGATÓRIO (ANTES de qualquer scoring)**
 
-Responde a estas 3 perguntas ANTES de atribuir qualquer score:
+Responde a estas perguntas ANTES de atribuir qualquer score:
+
+0. **PERFIL DO CANDIDATO PRESENTE?** (gate duro — verifica o CANDIDATO, não a posição)
+   - Se `$JHT_HOME/profile/candidate_profile.yml` falta, está vazio, ou não tem `target_role` → **STOP: NÃO calcules e NÃO guardes nenhum score.** Não há sinal suficiente sobre o candidato para que um score faça sentido. `db_insert.py score` recusa de qualquer forma a escrita neste estado (gate determinístico, `profile_gate.py`).
+   - **Ausente ≠ incompleto.** Um perfil parcial (alguns campos em falta) é normal: procede e usa o teu julgamento, penalizando a incerteza nas dimensões afetadas. Só o perfil substancialmente AUSENTE te trava.
+   - Quando bloqueado: deixa a posição em `checked` (o que está partido é o perfil, não a posição — nunca `excluded` por isto) e escala segundo RULE-T10: `[@scorer-N -> @capitano] [ESC] perfil candidato ausente — scoring suspenso`. Não inventes dados do perfil para prosseguir.
 
 1. **ANOS DE EXPERIÊNCIA REQUERIDOS?**
    - Significativamente mais que o candidato E mandatory = **EXCLUIR IMEDIATAMENTE** (score não atribuído)
@@ -145,7 +152,7 @@ python3 /app/shared/skills/db_query.py position <ID>
 ```
 
 **Para cada posição:**
-1. Pre-check (RULE-01) → se falha: `excluded`
+1. Pre-check (RULE-01) → ponto 0 falha (perfil ausente): STOP, a posição fica em `checked`, escala; pontos 1-3 falham (lado JD): `excluded`
 2. Verificação link (RULE-02)
 3. Claim (RULE-03)
 4. Calcula **base score** com a fórmula

--- a/shared/skills/db_insert.py
+++ b/shared/skills/db_insert.py
@@ -20,6 +20,7 @@ import os
 sys.path.insert(0, os.path.dirname(__file__))
 
 from _db import get_db, ensure_schema, resolve_company_id
+from profile_gate import check_minimum_viable_profile
 
 
 def extract_linkedin_job_id(url):
@@ -283,6 +284,20 @@ def _validate_score_range(value, name, min_val, max_val):
 
 
 def insert_score(args):
+    # Gate anti-scoring con profilo assente (incident 2026-07: score 45
+    # persistito per utente con profilo mai compilato). Precondizione
+    # DETERMINISTICA, non delegata all'agente: se il profilo non raggiunge il
+    # "minimum viable profile" (target_role + un secondo segnale — vedi
+    # profile_gate.py) lo score non ha senso e non viene scritto. NON è un
+    # check di completezza: i profili parziali passano e restano una
+    # valutazione qualitativa dello Scorer (RULE-01 punto 0).
+    viable, reason = check_minimum_viable_profile()
+    if not viable:
+        print(f"⚠️  SCORE RIFIUTATO: {reason}.")
+        print("    Il profilo candidato è sostanzialmente assente: non assegnare lo score.")
+        print("    Lascia la posizione in 'checked' ed escala al Capitano (RULE-T10 — do not invent).")
+        sys.exit(1)
+
     _validate_score_range(args.total, 'total', 0, 100)
     _validate_score_range(args.stack_match, 'stack_match', 0, 40)
     _validate_score_range(args.remote_fit, 'remote_fit', 0, 25)

--- a/shared/skills/profile_gate.py
+++ b/shared/skills/profile_gate.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""profile_gate.py — gate "minimum viable profile" per le scritture derivate dal profilo.
+
+Origin: incident 2026-07 — uno score (total 45, skill_match/location_fit NULL)
+è stato persistito per un utente con TUTTE le tabelle profilo vuote su cloud e
+candidate_profile.yml assente/vuoto in locale. Il divieto era applicato solo a
+monte (UI/onboarding via isProfileComplete); il motore a valle (agente Scorer +
+INSERT in scores) non lo replicava, e l'agente davanti al caso non previsto
+degradava in modo permissivo assegnando comunque un numero.
+
+Questo modulo è la precondizione DETERMINISTICA a valle: prima di persistere
+uno score, verifica che esista "abbastanza segnale sul candidato perché uno
+score abbia senso".
+
+⚠️ NON è un check di completezza. Un profilo parziale è normale e voluto:
+sopra questa soglia minima la decisione se scorare resta all'agente (giudizio
+qualitativo). NON usare validate_profile.py / isProfileComplete come gate qui:
+richiedono TUTTI i campi L1 e bloccherebbero profili parziali legittimi.
+
+Soglia (bassa e conservativa — blocca solo i casi degeneri):
+  1. candidate_profile.yml esiste, è YAML parsabile, ed è un dict non vuoto;
+  2. `target_role` valorizzato (root, candidate.target_role o target_roles[0])
+     — caso limite dichiarato dallo stakeholder: uno score senza nemmeno il
+     titolo/target professionale dell'utente non ha senso;
+  3. il template non è intatto (name != placeholder "Nome Cognome");
+  4. almeno UN secondo segnale tra: name, skills, experience_years,
+     location, languages, experience — un file con la SOLA riga target_role
+     è degenere quanto un file vuoto (ogni sub-score sarebbe incalcolabile),
+     mentre qualsiasi profilo reale anche solo iniziato ha almeno il nome.
+
+Uso da skill (import):
+    from profile_gate import check_minimum_viable_profile
+    ok, reason = check_minimum_viable_profile()
+
+Uso da CLI (exit 0 = profilo utilizzabile, exit 1 = assente):
+    python3 profile_gate.py [path/candidate_profile.yml]
+"""
+
+import os
+import sys
+
+# Placeholder del template docs/examples/candidate_profile.yml.example —
+# stesso criterio di web/lib/profile-reader.ts (readWorkspaceProfile).
+_PLACEHOLDER_NAME = "nome cognome"
+
+
+def _default_profile_path() -> str:
+    """$JHT_HOME/profile/candidate_profile.yml, fallback ~/.jht (come il web)."""
+    jht_home = os.environ.get('JHT_HOME') or os.path.expanduser(
+        os.path.join('~', '.jht'))
+    return os.path.join(jht_home, 'profile', 'candidate_profile.yml')
+
+
+def _first_str(*values):
+    """Prima stringa non vuota tra i candidati, else None."""
+    for v in values:
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _has_items(value) -> bool:
+    """True se lista/dict con almeno un elemento significativo."""
+    if isinstance(value, dict):
+        return any(_has_items(v) or _first_str(v) for v in value.values())
+    if isinstance(value, list):
+        return len(value) > 0
+    return False
+
+
+def check_minimum_viable_profile(path=None):
+    """Ritorna (ok: bool, reason: str). reason è vuota quando ok=True.
+
+    Fail-closed: qualsiasi stato in cui il profilo non è leggibile o è
+    sostanzialmente assente ritorna False — meglio uno scoring sospeso che
+    uno score inventato (RULE-T10: if a field your role needs is missing,
+    escalate — do not invent).
+    """
+    if path is None:
+        path = _default_profile_path()
+
+    if not os.path.isfile(path):
+        return False, f"profilo candidato assente: file non trovato ({path})"
+
+    try:
+        import yaml
+    except ImportError:
+        return False, ("pyyaml non disponibile: impossibile verificare il "
+                       "profilo (uv pip install --user pyyaml)")
+
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        return False, f"profilo candidato non parsabile (YAML invalido): {e}"
+    except OSError as e:
+        return False, f"profilo candidato non leggibile: {e}"
+
+    if not isinstance(data, dict) or not data:
+        return False, "profilo candidato vuoto (nessun campo compilato)"
+
+    candidate = data.get('candidate') if isinstance(data.get('candidate'), dict) else {}
+    personal = data.get('personal') if isinstance(data.get('personal'), dict) else {}
+    target_roles = data.get('target_roles') if isinstance(data.get('target_roles'), list) else []
+
+    target_role = _first_str(
+        data.get('target_role'),
+        candidate.get('target_role'),
+        target_roles[0] if target_roles else None,
+    )
+    if not target_role:
+        return False, ("profilo candidato senza titolo/target professionale "
+                       "(target_role): uno score senza nemmeno il target non ha senso")
+
+    name = _first_str(data.get('name'), candidate.get('name'), personal.get('name'))
+    if name and name.lower() == _PLACEHOLDER_NAME:
+        return False, ("profilo candidato = template non compilato "
+                       "(name placeholder 'Nome Cognome')")
+
+    # Secondo segnale minimo: senza NIENTE oltre al target_role ogni
+    # sub-score (stack, seniority, location, salary) resta incalcolabile.
+    has_second_signal = any((
+        name is not None,
+        _has_items(data.get('skills')) or _has_items(candidate.get('skills')),
+        isinstance(data.get('experience_years'), int) and not isinstance(data.get('experience_years'), bool),
+        _first_str(data.get('location'), personal.get('location')) is not None,
+        _has_items(data.get('languages')) or _has_items(candidate.get('languages')),
+        _has_items(data.get('experience')) or _has_items(candidate.get('experience')),
+    ))
+    if not has_second_signal:
+        return False, ("profilo candidato con il solo target_role: nessun altro "
+                       "segnale (nome, skills, esperienza, location o lingue)")
+
+    return True, ""
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    path = args[0] if args else None
+    ok, reason = check_minimum_viable_profile(path)
+    if ok:
+        print("PROFILE_VIABLE")
+        return 0
+    print(f"PROFILE_MISSING: {reason}", file=sys.stderr)
+    print("PROFILE_MISSING")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_score_profile_gate.py
+++ b/tests/test_score_profile_gate.py
@@ -1,0 +1,239 @@
+"""Test gate "minimum viable profile" su insert_score (shared/skills).
+
+Root cause coperta: incident 2026-07 — score persistito in `scores` per un
+utente con profilo mai compilato (candidate_profile.yml assente). Il gate
+UI/onboarding (isProfileComplete) non era replicato a valle e lo Scorer
+degradava in modo permissivo.
+
+Vincolo di design verificato qui: il gate blocca SOLO l'assenza sostanziale
+del profilo — i profili parziali (che NON passerebbero validate_profile.py /
+isProfileComplete) devono continuare a scorare. Non è una checklist di
+completezza.
+
+Eseguire:
+    pytest tests/test_score_profile_gate.py -v
+"""
+
+import argparse
+import os
+import sqlite3
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SKILLS_DIR = os.path.join(REPO_ROOT, 'shared', 'skills')
+
+sys.path.insert(0, SKILLS_DIR)
+import profile_gate  # noqa: E402
+import db_insert  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture profili
+# ---------------------------------------------------------------------------
+
+# Minimo valido: target_role + un secondo segnale (il nome). Sotto questo
+# livello lo score è insensato; questo DEVE passare.
+MINIMAL_PROFILE = """\
+name: "Test User"
+target_role: "Python Developer"
+"""
+
+# Parziale realistico: fallirebbe validate_profile.py (mancano location,
+# experience_years, has_degree, seniority_target, languages — tutti L1
+# mandatori) ma è ben sopra la soglia del gate. Regressione da NON rompere:
+# lo scoring con profili parziali è comportamento legittimo e voluto.
+PARTIAL_PROFILE = """\
+name: "Test User"
+target_role: "Data Engineer"
+skills:
+  primary:
+    - Python
+    - SQL
+"""
+
+# Solo target_role, nessun altro segnale: degenere quanto un file vuoto
+# (ogni sub-score sarebbe incalcolabile).
+ONLY_TARGET_PROFILE = """\
+target_role: "Python Developer"
+"""
+
+# Template docs/examples copiato ma mai compilato (placeholder name).
+PLACEHOLDER_PROFILE = """\
+name: "Nome Cognome"
+target_role: "Backend Developer"
+location: "Remote EU"
+"""
+
+# Schema annidato usato da alcuni produttori (candidate.target_role).
+NESTED_PROFILE = """\
+candidate:
+  name: "Test User"
+  target_role: "Frontend Developer"
+"""
+
+
+def _write_profile(tmp_path, content):
+    profile_dir = tmp_path / 'profile'
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    path = profile_dir / 'candidate_profile.yml'
+    path.write_text(content, encoding='utf-8')
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Unit test: check_minimum_viable_profile
+# ---------------------------------------------------------------------------
+
+class TestCheckMinimumViableProfile:
+
+    def test_missing_file_rejected(self, tmp_path):
+        ok, reason = profile_gate.check_minimum_viable_profile(
+            str(tmp_path / 'profile' / 'candidate_profile.yml'))
+        assert not ok
+        assert 'assente' in reason
+
+    def test_empty_file_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, '')
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+        assert 'vuoto' in reason
+
+    def test_yaml_not_dict_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, '- solo\n- una\n- lista\n')
+        ok, _ = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+
+    def test_invalid_yaml_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, 'name: "unclosed\n  {{{')
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+        assert 'parsabile' in reason
+
+    def test_no_target_role_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, 'name: "Test User"\nlocation: "Milano"\n')
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+        assert 'target' in reason
+
+    def test_only_target_role_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, ONLY_TARGET_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+        assert 'solo target_role' in reason
+
+    def test_placeholder_template_rejected(self, tmp_path):
+        path = _write_profile(tmp_path, PLACEHOLDER_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert not ok
+        assert 'template' in reason
+
+    def test_minimal_profile_allowed(self, tmp_path):
+        path = _write_profile(tmp_path, MINIMAL_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert ok, reason
+
+    def test_partial_profile_allowed(self, tmp_path):
+        """Profilo parziale (bocciato dal validatore L1) DEVE passare il gate."""
+        path = _write_profile(tmp_path, PARTIAL_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert ok, reason
+
+    def test_nested_candidate_schema_allowed(self, tmp_path):
+        path = _write_profile(tmp_path, NESTED_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert ok, reason
+
+    def test_target_roles_list_variant_allowed(self, tmp_path):
+        path = _write_profile(
+            tmp_path, 'target_roles:\n  - "DevOps Engineer"\nname: "Test User"\n')
+        ok, reason = profile_gate.check_minimum_viable_profile(path)
+        assert ok, reason
+
+    def test_default_path_reads_jht_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('JHT_HOME', str(tmp_path))
+        _write_profile(tmp_path, MINIMAL_PROFILE)
+        ok, reason = profile_gate.check_minimum_viable_profile()
+        assert ok, reason
+
+    def test_default_path_missing_jht_home_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('JHT_HOME', str(tmp_path))
+        ok, _ = profile_gate.check_minimum_viable_profile()
+        assert not ok
+
+
+# ---------------------------------------------------------------------------
+# Integration test: insert_score rifiuta/consente la scrittura in scores
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def score_db(tmp_path, monkeypatch):
+    """DB file temporaneo + get_db/ensure_schema patchati su db_insert."""
+    db_path = str(tmp_path / 'jobs.db')
+
+    def _get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                position_id INTEGER NOT NULL UNIQUE,
+                total_score INTEGER NOT NULL,
+                stack_match INTEGER,
+                remote_fit INTEGER,
+                salary_fit INTEGER,
+                experience_fit INTEGER,
+                strategic_fit INTEGER,
+                breakdown TEXT,
+                notes TEXT,
+                scored_by TEXT,
+                scored_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        return conn
+
+    monkeypatch.setattr(db_insert, 'get_db', _get_db)
+    monkeypatch.setattr(db_insert, 'ensure_schema', lambda conn: None)
+    return _get_db
+
+
+def _score_args(position_id=1, total=76):
+    return argparse.Namespace(
+        position_id=position_id, total=total,
+        stack_match=None, remote_fit=None, salary_fit=None,
+        experience_fit=None, strategic_fit=None,
+        breakdown=None, notes=None, scored_by='scorer-test',
+    )
+
+
+def _count_scores(get_db):
+    conn = get_db()
+    n = conn.execute("SELECT COUNT(*) FROM scores").fetchone()[0]
+    conn.close()
+    return n
+
+
+class TestInsertScoreGate:
+
+    def test_rejected_when_profile_missing(self, score_db, tmp_path, monkeypatch, capsys):
+        # JHT_HOME punta a una dir senza profile/ → gate scatta, niente riga.
+        monkeypatch.setenv('JHT_HOME', str(tmp_path / 'empty_home'))
+        with pytest.raises(SystemExit) as exc:
+            db_insert.insert_score(_score_args())
+        assert exc.value.code == 1
+        assert 'SCORE RIFIUTATO' in capsys.readouterr().out
+        assert _count_scores(score_db) == 0
+
+    def test_allowed_with_minimal_profile(self, score_db, tmp_path, monkeypatch):
+        monkeypatch.setenv('JHT_HOME', str(tmp_path))
+        _write_profile(tmp_path, MINIMAL_PROFILE)
+        db_insert.insert_score(_score_args(position_id=1, total=76))
+        assert _count_scores(score_db) == 1
+
+    def test_allowed_with_partial_profile(self, score_db, tmp_path, monkeypatch):
+        """Regressione: profilo parziale sopra soglia → lo scoring funziona."""
+        monkeypatch.setenv('JHT_HOME', str(tmp_path))
+        _write_profile(tmp_path, PARTIAL_PROFILE)
+        db_insert.insert_score(_score_args(position_id=2, total=61))
+        assert _count_scores(score_db) == 1


### PR DESCRIPTION
## 🐛 Root cause

In produzione è stato persistito uno score (`total_score = 45`, `skill_match`/`location_fit` NULL) per un utente con **zero righe in tutte le tabelle profilo** e `user_onboarding_state` vuoto. Catena del guasto:

1. **Il gate del profilo esisteva solo a monte** — `isProfileComplete()` (`web/lib/profile-reader.ts`) fa gating di UI/onboarding, ma non è una precondizione nel percorso di scoring.
2. **Profilo cloud ≠ profilo locale** — gli agenti leggono `$JHT_HOME/profile/candidate_profile.yml`, sincronizzato dal cloud; lo scoring è avvenuto con profilo cloud vuoto/non sincronizzato e niente a valle ha interrotto l'operazione.
3. **Lo Scorer non aveva blocchi difensivi** — `scorer.md` presuppone che il profilo esista; davanti al caso non previsto l'agente ha degradato in modo permissivo (ha annotato onestamente "profile missing" nelle notes… e ha assegnato comunque un numero).

## 🛡️ Fix — gate su due livelli

**1. Lato codice (deterministico, non aggirabile dall'agente)** — nuovo `shared/skills/profile_gate.py`: `db_insert.py score` rifiuta l'INSERT in `scores` (exit 1, messaggio azionabile) se il profilo non raggiunge il *minimum viable profile*. Fail-closed su: file assente, YAML invalido, dict vuoto, template placeholder intatto. Unico percorso agente di scrittura in `scores` verificato: `db_insert.py score` (il pull di `cli/cloud.js` è sync, non scoring).

**2. Lato istruzioni agente** — `scorer.md` (EN + 6 varianti lingua): nuovo **RULE-01 punto 0** nel pre-check: profilo assente → STOP, niente calcolo né salvataggio, posizione resta in `checked` (mai `excluded`: è il profilo a essere rotto, non la posizione), escalation al Capitano coerente con RULE-T10 ("if a field your role needs is missing, escalate — do not invent"). Nota anche in `agents/_manual/db-schema.md` (sezione `scores`).

## 📏 Soglia "minimum viable profile" (bassa e conservativa)

Blocca **solo l'assenza sostanziale**, mai l'incompletezza:

1. `candidate_profile.yml` esiste, YAML parsabile, dict non vuoto;
2. **`target_role` valorizzato** (root, `candidate.target_role` o `target_roles[0]`) — il caso limite dichiarato: uno score senza nemmeno il titolo/target dell'utente non ha senso;
3. template non intatto (name ≠ placeholder "Nome Cognome" — stesso criterio di `readWorkspaceProfile`);
4. **almeno un secondo segnale** tra nome, skills, esperienza, location, lingue — un file con la *sola* riga `target_role` è degenere quanto uno vuoto (ogni sub-score sarebbe incalcolabile), mentre qualsiasi profilo reale anche solo iniziato ha almeno il nome.

**Cosa NON fa**: non riusa `isProfileComplete()`/`validate_profile.py` (L1 completo — bloccherebbe profili parziali legittimi), nessuna checklist di campi obbligatori oltre il minimo, e sopra la soglia la decisione resta all'agente. Nessun dato di produzione toccato (lo score esistente dell'utente X resta).

## 🤝 Coerenza cross-agente

Writer verificato: già coperto da S-03 (zero invenzioni, fonte unica il profilo) + gate utente `write_requested = 1` (C-10) — il caso degenere non può avvenire in autonomia, nessun gate codice aggiunto lì (scope invariato salvo evidenza).

## ✅ Test

`tests/test_score_profile_gate.py` — 16 test, tutti verdi:
- profilo assente/vuoto/YAML invalido/solo-template/senza-target/solo-target → **score rifiutato** (SystemExit, tabella `scores` vuota);
- profilo minimo valido (`target_role` + nome) → **score consentito**;
- profilo parziale sopra soglia *che il validatore L1 boccerebbe* → **score consentito** (regressione da non rompere).

Suite esistente: `test_db_insert_dedup` + `test_scoring_logic` + `test_utility_scripts` = 75 passed. I failure residui su Windows (encoding cp1252 nel runner di `test_pipeline*`) sono identici sulla baseline `master` senza questo diff — pre-esistenti, non introdotti qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)