### PR TITLE
fix(launcher): bound tmux new-session with a timeout to prevent a permanent spawn lockout

### DIFF
--- a/.launcher/start-agent.sh
+++ b/.launcher/start-agent.sh
@@ -1104,7 +1104,26 @@ else
   # troncato a 80 colonne — leggibilità terribile nella webUI. 220x50 dà
   # margine per dashboard / task lists del CLI senza esagerare con i byte
   # da leggere a ogni tick.
-  tmux new-session -d -x 220 -y 50 -s "$SESSION" -c "$AGENT_DIR"
+  #
+  # `timeout` qui e' voluto: osservato in produzione (Docker Desktop /
+  # bind mount Windows) un `tmux new-session` che non ritorna mai — ne'
+  # crea la sessione ne' esce ne' fallisce, semplicemente resta appeso.
+  # Senza un limite, il processo tiene aperto per sempre il fd 9 del
+  # flock preso piu' sopra: ogni respawn successivo dello STESSO agente
+  # (watchdog, utente, capitano) va in timeout dopo i 30s di `flock -w`
+  # e fallisce con "concurrent spawn", indefinitamente — osservati 756
+  # respawn falliti in 37h su una singola installazione prima che la
+  # causa fosse isolata a un `tmux new-session` orfano di 15h+. `timeout`
+  # garantisce che questo branch ritorni sempre, cosi' il lock si libera
+  # e il prossimo tentativo puo' ripartire pulito invece di ripetere
+  # all'infinito lo stesso fallimento silenzioso.
+  if ! timeout 20 tmux new-session -d -x 220 -y 50 -s "$SESSION" -c "$AGENT_DIR"; then
+    echo "Error: 'tmux new-session' for '$SESSION' did not return within 20s (hung spawn)." >&2
+    # Pulizia best-effort: se tmux ha comunque registrato una sessione a
+    # meta', non lasciarla a meta' per il prossimo tentativo.
+    tmux kill-session -t "$SESSION" 2>/dev/null
+    exit 1
+  fi
   send_env_vars
   tmux send-keys -t "$SESSION" "$FULL_CMD" C-m
   # Auto-respond a TUI startup prompt: detect-and-respond invece di blind


### PR DESCRIPTION
## Summary

- `start-agent.sh`'s worker-spawn branch called `tmux new-session -d` with no timeout. On one installation (Docker Desktop for Windows, `JHT_HOME` bind-mounted from the host) this call hung indefinitely — no session created, no exit, no error.
- Because the per-agent spawn lock (`flock` on `locks/start-<SESSION>.lock`) is only released when the script exits, the hung process held that lock forever.
- Every subsequent respawn attempt for the same agent (watchdog tick, Capitano, manual `jht team start`) then blocked on the existing `flock -w 30` wait, timed out after 30s with a generic `"concurrent spawn"` error, and gave up — with no path back to a healthy state.
- On the installation where this was found, it produced **756 failed respawn attempts over 37 hours** for a single agent (ASSISTENTE) before the cause was isolated to one `tmux new-session` process that had been hung for 15+ hours.

## Fix

Wraps the call in `timeout 20` — the same pattern already used a few lines up for the CLI health-check spawn — so this branch is guaranteed to return one way or the other. On timeout it logs clearly and best-effort kills any partially-registered session before exiting, so the lock releases promptly and the next attempt starts clean instead of repeating the same silent failure forever.

## Testing

No test harness for this script that I could find, so verified manually inside a running `jht` container:

- **Normal spawn, no regression**: `timeout 20 tmux new-session -d -x 220 -y 50 -s ZZTEST -c /tmp` → exit 0, session created immediately (well under the 20s bound), cleaned up after.
- **Hang is now bounded**: `timeout 3 sh -c 'exec sleep 100'` → exits 124 (timeout) at ~3s elapsed, not 100s — confirming the wrapper actually bounds a stuck child process rather than just adding a cosmetic flag.

I don't have a reliable local repro for *why* `tmux new-session` itself hangs (suspect something Docker-Desktop/Windows-bind-mount specific), so this fix addresses the blast radius — a single hung spawn should never again be able to permanently lock an agent out of respawning — rather than the underlying tmux/environment cause.

## Scope

Deliberately limited to the one branch I could reproduce/confirm the failure mode on (the container-side single-session spawn at the bottom of the script). Left the `SENTINELLA-WORKER` short-circuit and the Windows PowerShell branch untouched since I have no evidence either hangs the same way, and didn't want to touch code paths I couldn't verify.