### PR TITLE
feat(launcher): auto-dismiss the Codex TUI's fullscreen pager when it hangs a headless agent session

### DIFF
--- a/.launcher/pager-unstick-watchdog.sh
+++ b/.launcher/pager-unstick-watchdog.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# pager-unstick-watchdog.sh — dismisses Codex TUI's built-in fullscreen
+# pager (opened automatically for long tool output) when it is left open
+# in a headless tmux session with nobody to press `q`.
+#
+# Observed repeatedly in production: a single `sed -n`/`cat` of a long
+# skill file or JD dump makes the Codex TUI switch to its internal
+# paginated viewer ("↑/↓ to scroll ... q to quit"). In an unattended
+# tmux session (no human terminal attached) that viewer sits forever —
+# the agent makes zero further progress until something sends `q`.
+# There is no Codex CLI flag/config to disable this (checked `codex
+# features list` and `~/.codex/config.toml` schema — nothing).
+#
+# This watchdog polls every agent's tmux pane, recognises the pager's
+# fixed footer text, sends `q`, and — since dismissing a pager sometimes
+# also interrupts the agent's in-flight turn (Codex shows "Conversation
+# interrupted") — sends a generic resume nudge so the agent doesn't just
+# sit on a dead prompt afterwards.
+#
+# Loop interval: 20s (configurable via JHT_PAGER_WATCHDOG_INTERVAL).
+# Same daemon pattern as agent-watchdog.sh / doctor-watchdog.sh: spawned
+# by pid1 at container boot, log-and-continue on any single-session
+# failure rather than fail-fast.
+set -u
+
+export PATH="/app/agents/_tools:${PATH}"
+
+JHT_HOME="${JHT_HOME:-/jht_home}"
+LOG="$JHT_HOME/logs/pager-unstick-watchdog.log"
+INTERVAL_SEC="${JHT_PAGER_WATCHDOG_INTERVAL:-20}"
+
+log() { printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG"; }
+
+log "pager-unstick-watchdog up — interval=${INTERVAL_SEC}s"
+
+while true; do
+  sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
+  for s in $sessions; do
+    tail3=$(tmux capture-pane -t "$s" -p -S -3 2>/dev/null || true)
+    # Both footer fragments together are the pager's fixed signature —
+    # specific enough to avoid matching normal agent chatter.
+    if printf '%s' "$tail3" | grep -q 'pgup/pgdn to page' \
+      && printf '%s' "$tail3" | grep -q 'q to quit'; then
+      log "session $s: stuck in pager, dismissing"
+      tmux send-keys -t "$s" q
+      sleep 1
+      after=$(tmux capture-pane -t "$s" -p -S -3 2>/dev/null || true)
+      if printf '%s' "$after" | grep -q 'Conversation interrupted'; then
+        jht-tmux-send "$s" "Continue where you left off." >>"$LOG" 2>&1 || true
+        log "session $s: dismissal interrupted the turn, sent resume nudge"
+      else
+        log "session $s: dismissed cleanly, no resume needed"
+      fi
+    fi
+  done
+  sleep "$INTERVAL_SEC"
+done

--- a/cli/src/commands/pid1.js
+++ b/cli/src/commands/pid1.js
@@ -43,6 +43,7 @@ const TEAM_HALTED_FLAG = `${JHT_HOME}/.team-halted.flag`;
 const PAIRING_TOKEN_PATH = `${JHT_HOME}/.pairing-token`;
 const TG_BRIDGE_LAUNCHER = '/app/.launcher/start-agent.sh';
 const AGENT_WATCHDOG_SCRIPT = '/app/.launcher/agent-watchdog.sh';
+const PAGER_UNSTICK_WATCHDOG_SCRIPT = '/app/.launcher/pager-unstick-watchdog.sh';
 const DOCTOR_WATCHDOG_SCRIPT = '/app/.launcher/doctor-watchdog.sh';
 const STEPCAP_WATCHDOG_SCRIPT = '/app/.launcher/stepcap-watchdog.py';
 const THROTTLE_ENGINE_SCRIPT = '/app/shared/skills/throttle_engine.py';
@@ -791,6 +792,40 @@ async function dispatch() {
   };
   startAgentWatchdog();
 
+  // ── Pager-unstick watchdog: tick ogni 20s, dismette il pager
+  // fullscreen del Codex TUI quando resta aperto in una sessione tmux
+  // headless (nessun umano davanti per premere `q`). Osservato ripetuto
+  // in produzione: un singolo `cat`/`sed -n` di uno skill file lungo o
+  // di una JD scaricata fa scattare il viewer paginato interno del TUI
+  // ("↑/↓ to scroll ... q to quit") — senza terminale attaccato resta
+  // aperto per sempre e l'agente non fa più nessun progresso. Nessuna
+  // config Codex (`codex features list`, `~/.codex/config.toml`) espone
+  // un modo per disattivarlo. Stesso pattern respawn-on-crash di
+  // startAgentWatchdog, spawnato subito dopo per lo stesso motivo:
+  // sub-second, deterministico, nessun LLM coinvolto.
+  let pagerUnstickChild = null;
+  let pagerUnstickRespawnTimer = null;
+  const startPagerUnstickWatchdog = () => {
+    if (pagerUnstickChild && !pagerUnstickChild.killed) return;
+    pid1Log('starting pager-unstick-watchdog (tmux session-level, tick 20s)');
+    pagerUnstickChild = spawnLabeled('pager-unstick', '/bin/bash', [PAGER_UNSTICK_WATCHDOG_SCRIPT]);
+    pagerUnstickChild.on('exit', (code, signal) => {
+      const exited = pagerUnstickChild;
+      pagerUnstickChild = null;
+      if (shuttingDown) return;
+      pid1Log(`pager-unstick-watchdog exited (code=${code} signal=${signal})`);
+      if (pagerUnstickRespawnTimer) clearTimeout(pagerUnstickRespawnTimer);
+      pagerUnstickRespawnTimer = setTimeout(() => {
+        if (!shuttingDown) {
+          pid1Log('pager-unstick-watchdog respawn after crashing');
+          startPagerUnstickWatchdog();
+        }
+      }, 5000);
+      void exited;
+    });
+  };
+  startPagerUnstickWatchdog();
+
   // ── Auto-report loop: panoramica grafica + PNG via Telegram ogni 2h
   // (decisione utente 2026-05-17 — bug #16 / task #52 / F-1.D). Loop
   // bash che ogni 5 min chiama auto_report.py; lo script throttle
@@ -1183,6 +1218,8 @@ async function dispatch() {
     if (fileBridgeChild && !fileBridgeChild.killed) fileBridgeChild.kill(sig);
     if (watchdogChild && !watchdogChild.killed) watchdogChild.kill(sig);
     if (watchdogRespawnTimer) clearTimeout(watchdogRespawnTimer);
+    if (pagerUnstickChild && !pagerUnstickChild.killed) pagerUnstickChild.kill(sig);
+    if (pagerUnstickRespawnTimer) clearTimeout(pagerUnstickRespawnTimer);
     if (doctorWatchdogChild && !doctorWatchdogChild.killed) doctorWatchdogChild.kill(sig);
     if (doctorWatchdogRespawnTimer) clearTimeout(doctorWatchdogRespawnTimer);
     if (stepcapChild && !stepcapChild.killed) stepcapChild.kill(sig);


### PR DESCRIPTION
## Problem

A single `cat`/`sed -n` of a long skill file, a downloaded JD, or the candidate profile is enough to make the Codex TUI switch into its internal fullscreen pager (`↑/↓ to scroll ... q to quit`). That's fine with a human at a terminal — every jht agent runs headless in tmux, so there's nobody there to press `q`, and the session sits frozen indefinitely: no more tool calls, no more progress, nothing.

Observed repeatedly this week in production: across a single CV-writing pass (Scrittore + a chain of ephemeral Critico instances working through a 3-round review loop), this happened **9 separate times over ~2.5 hours**. Each one needed a human to notice the session was frozen, `tmux send-keys q`, and often also send a resume nudge, since dismissing the pager sometimes also surfaces Codex's own "Conversation interrupted" state.

I checked for an existing fix before writing this:
- `codex features list` — nothing pager/transcript/view related
- `~/.codex/config.toml` schema — no relevant key
- It's an in-process TUI viewer, not a shelled-out `less`, so there's no `PAGER` env var to override

## Fix

A fifth watchdog, `pager-unstick-watchdog.sh`, same shape as the existing four:
- Every 20s, scans every tmux session's last few lines for the pager's fixed footer text (`pgup/pgdn to page` + `q to quit`)
- Sends `q` if found
- If that dismissal surfaced `Conversation interrupted`, sends a generic "Continue where you left off" nudge via `jht-tmux-send` — the same tool agents already use to message each other

Wired into `pid1.js` with the identical `spawnLabeled` / respawn-on-crash / shutdown-cleanup pattern as `startAgentWatchdog`, right after it.

## Testing

No test harness for this in the repo that I could find, so verified manually against a running `jht` container:

- Deployed the exact file from this branch to its real `/app/.launcher/` path and launched it the same way `pid1` does (not just syntax-checked in isolation)
- Confirmed it left ~10 real, actively-working agent sessions alone — no false positives
- Simulated the pager's exact footer text in a throwaway tmux session; the watchdog detected and dismissed it on its very first tick (log timestamps 21s apart, matching the configured 20s interval)
- It also caught a real, naturally-occurring hang (on `DOTTORE`) within seconds of being started, before I ran any synthetic test — i.e., this isn't a hypothetical, it was actively firing on the installation where I found the bug

## Scope

This treats the symptom (a stuck viewer with nobody to dismiss it), not why Codex opens the pager in the first place — I don't have visibility into that threshold from the jht side, and it may simply be inherent to running an interactive TUI headless. Happy to adjust the detection window/footer signature if it turns out to be too narrow or too broad on other setups.